### PR TITLE
Fixes #7 - Extra characters in groups.plist's

### DIFF
--- a/source/OFLGoudyStM-Italic.ufo/groups.plist
+++ b/source/OFLGoudyStM-Italic.ufo/groups.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>@MMK_L_A</key>
 	<array>
-		<string>A'</string>
+		<string>A</string>
 		<string>Aacute</string>
 		<string>Abreve</string>
 		<string>Acircumflex</string>
@@ -17,16 +17,16 @@
 	</array>
 	<key>@MMK_L_AE</key>
 	<array>
-		<string>AE'</string>
+		<string>AE</string>
 		<string>OE</string>
 	</array>
 	<key>@MMK_L_B</key>
 	<array>
-		<string>B'</string>
+		<string>B</string>
 	</array>
 	<key>@MMK_L_C</key>
 	<array>
-		<string>C'</string>
+		<string>C</string>
 		<string>Cacute</string>
 		<string>Ccaron</string>
 		<string>Ccedilla</string>
@@ -35,14 +35,14 @@
 	</array>
 	<key>@MMK_L_D</key>
 	<array>
-		<string>D'</string>
+		<string>D</string>
 		<string>Dcaron</string>
 		<string>Dcroat</string>
 		<string>Eth</string>
 	</array>
 	<key>@MMK_L_E</key>
 	<array>
-		<string>E'</string>
+		<string>E</string>
 		<string>Eacute</string>
 		<string>Ebreve</string>
 		<string>Ecaron</string>
@@ -55,15 +55,15 @@
 	</array>
 	<key>@MMK_L_Euro</key>
 	<array>
-		<string>Euro'</string>
+		<string>Euro</string>
 	</array>
 	<key>@MMK_L_F</key>
 	<array>
-		<string>F'</string>
+		<string>F</string>
 	</array>
 	<key>@MMK_L_G</key>
 	<array>
-		<string>G'</string>
+		<string>G</string>
 		<string>Gbreve</string>
 		<string>Gcircumflex</string>
 		<string>Gcommaaccent</string>
@@ -76,13 +76,13 @@
 	</array>
 	<key>@MMK_L_H</key>
 	<array>
-		<string>H'</string>
+		<string>H</string>
 		<string>Hbar</string>
 		<string>Hcircumflex</string>
 	</array>
 	<key>@MMK_L_I</key>
 	<array>
-		<string>I'</string>
+		<string>I</string>
 		<string>Ibreve</string>
 		<string>Icircumflex</string>
 		<string>Idotaccent</string>
@@ -91,23 +91,23 @@
 	</array>
 	<key>@MMK_L_Iacute</key>
 	<array>
-		<string>Iacute'</string>
+		<string>Iacute</string>
 	</array>
 	<key>@MMK_L_Idieresis</key>
 	<array>
-		<string>Idieresis'</string>
+		<string>Idieresis</string>
 	</array>
 	<key>@MMK_L_Iogonek</key>
 	<array>
-		<string>Iogonek'</string>
+		<string>Iogonek</string>
 	</array>
 	<key>@MMK_L_Itilde</key>
 	<array>
-		<string>Itilde'</string>
+		<string>Itilde</string>
 	</array>
 	<key>@MMK_L_J</key>
 	<array>
-		<string>IJ'</string>
+		<string>IJ</string>
 		<string>J</string>
 		<string>Jcircumflex</string>
 		<string>J.001</string>
@@ -115,33 +115,33 @@
 	</array>
 	<key>@MMK_L_K</key>
 	<array>
-		<string>K'</string>
+		<string>K</string>
 		<string>Kcommaaccent</string>
 	</array>
 	<key>@MMK_L_L</key>
 	<array>
-		<string>L'</string>
+		<string>L</string>
 		<string>Lacute</string>
 		<string>Lcaron</string>
 		<string>Lcommaaccent</string>
 	</array>
 	<key>@MMK_L_Ldot</key>
 	<array>
-		<string>Ldot'</string>
+		<string>Ldot</string>
 	</array>
 	<key>@MMK_L_Lslash</key>
 	<array>
-		<string>Lslash'</string>
+		<string>Lslash</string>
 		<string>quotedblbase</string>
 		<string>quotesinglbase</string>
 	</array>
 	<key>@MMK_L_M</key>
 	<array>
-		<string>M'</string>
+		<string>M</string>
 	</array>
 	<key>@MMK_L_N</key>
 	<array>
-		<string>N'</string>
+		<string>N</string>
 		<string>Nacute</string>
 		<string>Ncaron</string>
 		<string>Ncommaaccent</string>
@@ -149,7 +149,7 @@
 	</array>
 	<key>@MMK_L_O</key>
 	<array>
-		<string>O'</string>
+		<string>O</string>
 		<string>Oacute</string>
 		<string>Obreve</string>
 		<string>Ocircumflex</string>
@@ -162,26 +162,26 @@
 	</array>
 	<key>@MMK_L_P</key>
 	<array>
-		<string>P'</string>
+		<string>P</string>
 	</array>
 	<key>@MMK_L_Q</key>
 	<array>
-		<string>Q'</string>
+		<string>Q</string>
 	</array>
 	<key>@MMK_L_Q_u</key>
 	<array>
-		<string>Q_u'</string>
+		<string>Q_u</string>
 	</array>
 	<key>@MMK_L_R</key>
 	<array>
-		<string>R'</string>
+		<string>R</string>
 		<string>Racute</string>
 		<string>Rcaron</string>
 		<string>Rcommaaccent</string>
 	</array>
 	<key>@MMK_L_S</key>
 	<array>
-		<string>S'</string>
+		<string>S</string>
 		<string>Sacute</string>
 		<string>Scaron</string>
 		<string>Scedilla</string>
@@ -190,33 +190,33 @@
 	</array>
 	<key>@MMK_L_T</key>
 	<array>
-		<string>T'</string>
+		<string>T</string>
 		<string>Tcaron</string>
 		<string>Tcedilla</string>
 		<string>Tcommaaccent</string>
 	</array>
 	<key>@MMK_L_T.001</key>
 	<array>
-		<string>T.001'</string>
+		<string>T.001</string>
 		<string>Tcaron.001</string>
 		<string>Tcedilla.001</string>
 		<string>Tcommaaccent.001</string>
 	</array>
 	<key>@MMK_L_Tbar</key>
 	<array>
-		<string>Tbar'</string>
+		<string>Tbar</string>
 	</array>
 	<key>@MMK_L_Tbar.001</key>
 	<array>
-		<string>Tbar.001'</string>
+		<string>Tbar.001</string>
 	</array>
 	<key>@MMK_L_Thorn</key>
 	<array>
-		<string>Thorn'</string>
+		<string>Thorn</string>
 	</array>
 	<key>@MMK_L_U</key>
 	<array>
-		<string>U'</string>
+		<string>U</string>
 		<string>Uacute</string>
 		<string>Ubreve</string>
 		<string>Ucircumflex</string>
@@ -230,41 +230,41 @@
 	</array>
 	<key>@MMK_L_V</key>
 	<array>
-		<string>V'</string>
+		<string>V</string>
 	</array>
 	<key>@MMK_L_W</key>
 	<array>
-		<string>W'</string>
+		<string>W</string>
 		<string>Wcircumflex</string>
 	</array>
 	<key>@MMK_L_X</key>
 	<array>
-		<string>X'</string>
+		<string>X</string>
 	</array>
 	<key>@MMK_L_Y</key>
 	<array>
-		<string>Y'</string>
+		<string>Y</string>
 		<string>Yacute</string>
 		<string>Ycircumflex</string>
 		<string>Ydieresis</string>
 	</array>
 	<key>@MMK_L_Y.001</key>
 	<array>
-		<string>Y.001'</string>
+		<string>Y.001</string>
 		<string>Yacute.001</string>
 		<string>Ycircumflex.001</string>
 		<string>Ydieresis.001</string>
 	</array>
 	<key>@MMK_L_Z</key>
 	<array>
-		<string>Z'</string>
+		<string>Z</string>
 		<string>Zacute</string>
 		<string>Zcaron</string>
 		<string>Zdotaccent</string>
 	</array>
 	<key>@MMK_L_a</key>
 	<array>
-		<string>a'</string>
+		<string>a</string>
 		<string>acircumflex</string>
 		<string>agrave</string>
 		<string>amacron</string>
@@ -285,56 +285,56 @@
 	</array>
 	<key>@MMK_L_aacute</key>
 	<array>
-		<string>aacute'</string>
+		<string>aacute</string>
 	</array>
 	<key>@MMK_L_abreve</key>
 	<array>
-		<string>abreve'</string>
+		<string>abreve</string>
 	</array>
 	<key>@MMK_L_adieresis</key>
 	<array>
-		<string>adieresis'</string>
+		<string>adieresis</string>
 	</array>
 	<key>@MMK_L_ae</key>
 	<array>
-		<string>ae'</string>
+		<string>ae</string>
 		<string>oe</string>
 	</array>
 	<key>@MMK_L_ampersand</key>
 	<array>
-		<string>ampersand'</string>
+		<string>ampersand</string>
 	</array>
 	<key>@MMK_L_asciicircum</key>
 	<array>
-		<string>guillemotleft.uppercase'</string>
+		<string>guillemotleft.uppercase</string>
 		<string>guilsinglleft.uppercase</string>
 		<string>asciicircum</string>
 	</array>
 	<key>@MMK_L_asterisk</key>
 	<array>
-		<string>asterisk'</string>
+		<string>asterisk</string>
 	</array>
 	<key>@MMK_L_at</key>
 	<array>
-		<string>at'</string>
+		<string>at</string>
 		<string>copyright</string>
 	</array>
 	<key>@MMK_L_atilde</key>
 	<array>
-		<string>atilde'</string>
+		<string>atilde</string>
 	</array>
 	<key>@MMK_L_b</key>
 	<array>
-		<string>b'</string>
+		<string>b</string>
 		<string>f_b</string>
 	</array>
 	<key>@MMK_L_backslash</key>
 	<array>
-		<string>backslash'</string>
+		<string>backslash</string>
 	</array>
 	<key>@MMK_L_bar</key>
 	<array>
-		<string>zero.lining'</string>
+		<string>zero.lining</string>
 		<string>one.lining</string>
 		<string>two.lining</string>
 		<string>three.lining</string>
@@ -372,86 +372,86 @@
 	</array>
 	<key>@MMK_L_braceleft</key>
 	<array>
-		<string>braceleft'</string>
+		<string>braceleft</string>
 	</array>
 	<key>@MMK_L_bracketleft</key>
 	<array>
-		<string>bracketleft'</string>
+		<string>bracketleft</string>
 	</array>
 	<key>@MMK_L_bracketleft.uppercase</key>
 	<array>
-		<string>braceleft.uppercase'</string>
+		<string>braceleft.uppercase</string>
 		<string>bracketleft.uppercase</string>
 	</array>
 	<key>@MMK_L_bracketright</key>
 	<array>
-		<string>braceright'</string>
+		<string>braceright</string>
 		<string>bracketright</string>
 	</array>
 	<key>@MMK_L_bracketright.uppercase</key>
 	<array>
-		<string>braceright.uppercase'</string>
+		<string>braceright.uppercase</string>
 		<string>bracketright.uppercase</string>
 	</array>
 	<key>@MMK_L_bullet.001</key>
 	<array>
-		<string>bullet.001'</string>
+		<string>bullet.001</string>
 	</array>
 	<key>@MMK_L_c</key>
 	<array>
-		<string>c'</string>
+		<string>c</string>
 		<string>ccedilla</string>
 		<string>cent</string>
 	</array>
 	<key>@MMK_L_c_t</key>
 	<array>
-		<string>c_t'</string>
+		<string>c_t</string>
 	</array>
 	<key>@MMK_L_cacute</key>
 	<array>
-		<string>cacute'</string>
+		<string>cacute</string>
 	</array>
 	<key>@MMK_L_ccaron</key>
 	<array>
-		<string>ccaron'</string>
+		<string>ccaron</string>
 	</array>
 	<key>@MMK_L_ccircumflex</key>
 	<array>
-		<string>ccircumflex'</string>
+		<string>ccircumflex</string>
 	</array>
 	<key>@MMK_L_cdotaccent</key>
 	<array>
-		<string>cdotaccent'</string>
+		<string>cdotaccent</string>
 	</array>
 	<key>@MMK_L_colon</key>
 	<array>
-		<string>colon'</string>
+		<string>colon</string>
 		<string>semicolon</string>
 	</array>
 	<key>@MMK_L_comma</key>
 	<array>
-		<string>comma'</string>
+		<string>comma</string>
 	</array>
 	<key>@MMK_L_d</key>
 	<array>
-		<string>d'</string>
+		<string>d</string>
 		<string>dcaron</string>
 	</array>
 	<key>@MMK_L_dcroat</key>
 	<array>
-		<string>dcroat'</string>
+		<string>dcroat</string>
 	</array>
 	<key>@MMK_L_degree</key>
 	<array>
-		<string>degree'</string>
+		<string>degree</string>
 	</array>
 	<key>@MMK_L_dollar</key>
 	<array>
-		<string>dollar'</string>
+		<string>dollar</string>
 	</array>
 	<key>@MMK_L_dollar.lining.sub</key>
 	<array>
-		<string>zero.lining.sub'</string>
+		<string>zero.lining.sub</string>
 		<string>one.lining.sub</string>
 		<string>two.lining.sub</string>
 		<string>three.lining.sub</string>
@@ -471,117 +471,117 @@
 	</array>
 	<key>@MMK_L_dotlessj</key>
 	<array>
-		<string>dotlessj'</string>
+		<string>dotlessj</string>
 	</array>
 	<key>@MMK_L_e</key>
 	<array>
-		<string>e'</string>
+		<string>e</string>
 	</array>
 	<key>@MMK_L_eacute</key>
 	<array>
-		<string>eacute'</string>
+		<string>eacute</string>
 	</array>
 	<key>@MMK_L_ebreve</key>
 	<array>
-		<string>ebreve'</string>
+		<string>ebreve</string>
 	</array>
 	<key>@MMK_L_ecaron</key>
 	<array>
-		<string>ecaron'</string>
+		<string>ecaron</string>
 	</array>
 	<key>@MMK_L_ecircumflex</key>
 	<array>
-		<string>ecircumflex'</string>
+		<string>ecircumflex</string>
 	</array>
 	<key>@MMK_L_edieresis</key>
 	<array>
-		<string>edieresis'</string>
+		<string>edieresis</string>
 	</array>
 	<key>@MMK_L_edotaccent</key>
 	<array>
-		<string>edotaccent'</string>
+		<string>edotaccent</string>
 	</array>
 	<key>@MMK_L_egrave</key>
 	<array>
-		<string>egrave'</string>
+		<string>egrave</string>
 	</array>
 	<key>@MMK_L_eight</key>
 	<array>
-		<string>eight'</string>
+		<string>eight</string>
 	</array>
 	<key>@MMK_L_emacron</key>
 	<array>
-		<string>emacron'</string>
+		<string>emacron</string>
 	</array>
 	<key>@MMK_L_eogonek</key>
 	<array>
-		<string>eogonek'</string>
+		<string>eogonek</string>
 	</array>
 	<key>@MMK_L_eth</key>
 	<array>
-		<string>eth'</string>
+		<string>eth</string>
 	</array>
 	<key>@MMK_L_exclam</key>
 	<array>
-		<string>exclam'</string>
+		<string>exclam</string>
 		<string>exclamdown</string>
 		<string>questiondown</string>
 	</array>
 	<key>@MMK_L_f</key>
 	<array>
-		<string>f'</string>
+		<string>f</string>
 		<string>florin</string>
 	</array>
 	<key>@MMK_L_f_f</key>
 	<array>
-		<string>f_f'</string>
+		<string>f_f</string>
 	</array>
 	<key>@MMK_L_f_f_b</key>
 	<array>
-		<string>f_f_b'</string>
+		<string>f_f_b</string>
 	</array>
 	<key>@MMK_L_f_h</key>
 	<array>
-		<string>f_h'</string>
+		<string>f_h</string>
 	</array>
 	<key>@MMK_L_f_k</key>
 	<array>
-		<string>f_k'</string>
+		<string>f_k</string>
 	</array>
 	<key>@MMK_L_f_l</key>
 	<array>
-		<string>f_f_l'</string>
+		<string>f_f_l</string>
 		<string>f_l</string>
 	</array>
 	<key>@MMK_L_five</key>
 	<array>
-		<string>five'</string>
+		<string>five</string>
 	</array>
 	<key>@MMK_L_four</key>
 	<array>
-		<string>four'</string>
+		<string>four</string>
 	</array>
 	<key>@MMK_L_g</key>
 	<array>
-		<string>g'</string>
+		<string>g</string>
 		<string>gcommaaccent</string>
 		<string>gdotaccent</string>
 	</array>
 	<key>@MMK_L_gbreve</key>
 	<array>
-		<string>gbreve'</string>
+		<string>gbreve</string>
 	</array>
 	<key>@MMK_L_gcircumflex</key>
 	<array>
-		<string>gcircumflex'</string>
+		<string>gcircumflex</string>
 	</array>
 	<key>@MMK_L_germandbls</key>
 	<array>
-		<string>germandbls'</string>
+		<string>germandbls</string>
 	</array>
 	<key>@MMK_L_grave</key>
 	<array>
-		<string>onequarter'</string>
+		<string>onequarter</string>
 		<string>onehalf</string>
 		<string>threequarters</string>
 		<string>zero.lining.numer</string>
@@ -665,32 +665,32 @@
 	</array>
 	<key>@MMK_L_guillemotleft</key>
 	<array>
-		<string>guillemotleft'</string>
+		<string>guillemotleft</string>
 		<string>guilsinglleft</string>
 	</array>
 	<key>@MMK_L_guillemotright</key>
 	<array>
-		<string>guillemotright'</string>
+		<string>guillemotright</string>
 	</array>
 	<key>@MMK_L_guillemotright.uppercase</key>
 	<array>
-		<string>guillemotright.uppercase'</string>
+		<string>guillemotright.uppercase</string>
 		<string>guilsinglright.uppercase</string>
 	</array>
 	<key>@MMK_L_guilsinglright</key>
 	<array>
-		<string>guilsinglright'</string>
+		<string>guilsinglright</string>
 	</array>
 	<key>@MMK_L_h</key>
 	<array>
-		<string>h'</string>
+		<string>h</string>
 		<string>hbar</string>
 		<string>hcircumflex</string>
 		<string>f_f_h</string>
 	</array>
 	<key>@MMK_L_hyphen</key>
 	<array>
-		<string>zero'</string>
+		<string>zero</string>
 		<string>fraction</string>
 		<string>emdash</string>
 		<string>endash</string>
@@ -704,174 +704,174 @@
 	</array>
 	<key>@MMK_L_i</key>
 	<array>
-		<string>i'</string>
+		<string>i</string>
 		<string>iogonek</string>
 		<string>i.TRK</string>
 	</array>
 	<key>@MMK_L_iacute</key>
 	<array>
-		<string>iacute'</string>
+		<string>iacute</string>
 	</array>
 	<key>@MMK_L_ibreve</key>
 	<array>
-		<string>ibreve'</string>
+		<string>ibreve</string>
 	</array>
 	<key>@MMK_L_icircumflex</key>
 	<array>
-		<string>icircumflex'</string>
+		<string>icircumflex</string>
 	</array>
 	<key>@MMK_L_idieresis</key>
 	<array>
-		<string>idieresis'</string>
+		<string>idieresis</string>
 	</array>
 	<key>@MMK_L_igrave</key>
 	<array>
-		<string>igrave'</string>
+		<string>igrave</string>
 	</array>
 	<key>@MMK_L_imacron</key>
 	<array>
-		<string>imacron'</string>
+		<string>imacron</string>
 	</array>
 	<key>@MMK_L_itilde</key>
 	<array>
-		<string>itilde'</string>
+		<string>itilde</string>
 	</array>
 	<key>@MMK_L_j</key>
 	<array>
-		<string>ij'</string>
+		<string>ij</string>
 		<string>j</string>
 	</array>
 	<key>@MMK_L_jcircumflex</key>
 	<array>
-		<string>jcircumflex'</string>
+		<string>jcircumflex</string>
 	</array>
 	<key>@MMK_L_k</key>
 	<array>
-		<string>k'</string>
+		<string>k</string>
 		<string>kcommaaccent</string>
 		<string>f_f_k</string>
 	</array>
 	<key>@MMK_L_l</key>
 	<array>
-		<string>l'</string>
+		<string>l</string>
 		<string>lacute</string>
 		<string>lcaron</string>
 		<string>lcommaaccent</string>
 	</array>
 	<key>@MMK_L_ldot</key>
 	<array>
-		<string>ldot'</string>
+		<string>ldot</string>
 	</array>
 	<key>@MMK_L_longs</key>
 	<array>
-		<string>longs'</string>
+		<string>longs</string>
 	</array>
 	<key>@MMK_L_lslash</key>
 	<array>
-		<string>lslash'</string>
+		<string>lslash</string>
 	</array>
 	<key>@MMK_L_nacute</key>
 	<array>
-		<string>nacute'</string>
+		<string>nacute</string>
 	</array>
 	<key>@MMK_L_nine</key>
 	<array>
-		<string>nine'</string>
+		<string>nine</string>
 	</array>
 	<key>@MMK_L_ntilde</key>
 	<array>
-		<string>ntilde'</string>
+		<string>ntilde</string>
 	</array>
 	<key>@MMK_L_numbersign</key>
 	<array>
-		<string>f_f_i'</string>
+		<string>f_f_i</string>
 		<string>f_i</string>
 		<string>numbersign</string>
 		<string>currency</string>
 	</array>
 	<key>@MMK_L_o</key>
 	<array>
-		<string>o'</string>
+		<string>o</string>
 		<string>ograve</string>
 		<string>oslash</string>
 	</array>
 	<key>@MMK_L_oacute</key>
 	<array>
-		<string>oacute'</string>
+		<string>oacute</string>
 	</array>
 	<key>@MMK_L_obreve</key>
 	<array>
-		<string>obreve'</string>
+		<string>obreve</string>
 	</array>
 	<key>@MMK_L_ocircumflex</key>
 	<array>
-		<string>ocircumflex'</string>
+		<string>ocircumflex</string>
 	</array>
 	<key>@MMK_L_odieresis</key>
 	<array>
-		<string>odieresis'</string>
+		<string>odieresis</string>
 	</array>
 	<key>@MMK_L_ohungarumlaut</key>
 	<array>
-		<string>ohungarumlaut'</string>
+		<string>ohungarumlaut</string>
 	</array>
 	<key>@MMK_L_omacron</key>
 	<array>
-		<string>omacron'</string>
+		<string>omacron</string>
 	</array>
 	<key>@MMK_L_one</key>
 	<array>
-		<string>one'</string>
+		<string>one</string>
 	</array>
 	<key>@MMK_L_ordfeminine</key>
 	<array>
-		<string>ordfeminine'</string>
+		<string>ordfeminine</string>
 	</array>
 	<key>@MMK_L_ordmasculine</key>
 	<array>
-		<string>ordmasculine'</string>
+		<string>ordmasculine</string>
 	</array>
 	<key>@MMK_L_otilde</key>
 	<array>
-		<string>otilde'</string>
+		<string>otilde</string>
 	</array>
 	<key>@MMK_L_p</key>
 	<array>
-		<string>p'</string>
+		<string>p</string>
 		<string>thorn</string>
 	</array>
 	<key>@MMK_L_paragraph</key>
 	<array>
-		<string>paragraph'</string>
+		<string>paragraph</string>
 	</array>
 	<key>@MMK_L_parenleft</key>
 	<array>
-		<string>parenleft'</string>
+		<string>parenleft</string>
 	</array>
 	<key>@MMK_L_parenleft.uppercase</key>
 	<array>
-		<string>parenleft.uppercase'</string>
+		<string>parenleft.uppercase</string>
 	</array>
 	<key>@MMK_L_parenright</key>
 	<array>
-		<string>parenright'</string>
+		<string>parenright</string>
 	</array>
 	<key>@MMK_L_parenright.uppercase</key>
 	<array>
-		<string>parenright.uppercase'</string>
+		<string>parenright.uppercase</string>
 	</array>
 	<key>@MMK_L_percent</key>
 	<array>
-		<string>percent'</string>
+		<string>percent</string>
 	</array>
 	<key>@MMK_L_period</key>
 	<array>
-		<string>ellipsis'</string>
+		<string>ellipsis</string>
 		<string>period</string>
 	</array>
 	<key>@MMK_L_periodcentered</key>
 	<array>
-		<string>bullet'</string>
+		<string>bullet</string>
 		<string>periodcentered</string>
 		<string>emdash.uppercase</string>
 		<string>endash.uppercase</string>
@@ -884,7 +884,7 @@
 	</array>
 	<key>@MMK_L_plus</key>
 	<array>
-		<string>dotlessi'</string>
+		<string>dotlessi</string>
 		<string>three</string>
 		<string>divide</string>
 		<string>equal</string>
@@ -899,84 +899,84 @@
 	</array>
 	<key>@MMK_L_q</key>
 	<array>
-		<string>q'</string>
+		<string>q</string>
 	</array>
 	<key>@MMK_L_question</key>
 	<array>
-		<string>question'</string>
+		<string>question</string>
 	</array>
 	<key>@MMK_L_quotedbl</key>
 	<array>
-		<string>quotedbl'</string>
+		<string>quotedbl</string>
 		<string>quotesingle</string>
 		<string>quotedblright</string>
 		<string>quoteright</string>
 	</array>
 	<key>@MMK_L_quoteleft</key>
 	<array>
-		<string>quotedblleft'</string>
+		<string>quotedblleft</string>
 		<string>quoteleft</string>
 		<string>quotereversed</string>
 		<string>uni201F</string>
 	</array>
 	<key>@MMK_L_r</key>
 	<array>
-		<string>r'</string>
+		<string>r</string>
 		<string>rcommaaccent</string>
 	</array>
 	<key>@MMK_L_racute</key>
 	<array>
-		<string>racute'</string>
+		<string>racute</string>
 	</array>
 	<key>@MMK_L_rcaron</key>
 	<array>
-		<string>rcaron'</string>
+		<string>rcaron</string>
 	</array>
 	<key>@MMK_L_registered</key>
 	<array>
-		<string>registered'</string>
+		<string>registered</string>
 	</array>
 	<key>@MMK_L_s</key>
 	<array>
-		<string>s'</string>
+		<string>s</string>
 		<string>scedilla</string>
 		<string>scommaaccent</string>
 	</array>
 	<key>@MMK_L_sacute</key>
 	<array>
-		<string>sacute'</string>
+		<string>sacute</string>
 	</array>
 	<key>@MMK_L_scaron</key>
 	<array>
-		<string>scaron'</string>
+		<string>scaron</string>
 	</array>
 	<key>@MMK_L_scircumflex</key>
 	<array>
-		<string>scircumflex'</string>
+		<string>scircumflex</string>
 	</array>
 	<key>@MMK_L_section</key>
 	<array>
-		<string>section'</string>
+		<string>section</string>
 	</array>
 	<key>@MMK_L_seven</key>
 	<array>
-		<string>seven'</string>
+		<string>seven</string>
 	</array>
 	<key>@MMK_L_six</key>
 	<array>
-		<string>six'</string>
+		<string>six</string>
 	</array>
 	<key>@MMK_L_slash</key>
 	<array>
-		<string>slash'</string>
+		<string>slash</string>
 	</array>
 	<key>@MMK_L_sterling</key>
 	<array>
-		<string>sterling'</string>
+		<string>sterling</string>
 	</array>
 	<key>@MMK_L_t</key>
 	<array>
-		<string>t'</string>
+		<string>t</string>
 		<string>tbar</string>
 		<string>tcaron</string>
 		<string>tcedilla</string>
@@ -984,74 +984,74 @@
 	</array>
 	<key>@MMK_L_two</key>
 	<array>
-		<string>two'</string>
+		<string>two</string>
 	</array>
 	<key>@MMK_L_udieresis</key>
 	<array>
-		<string>udieresis'</string>
+		<string>udieresis</string>
 	</array>
 	<key>@MMK_L_uhungarumlaut</key>
 	<array>
-		<string>uhungarumlaut'</string>
+		<string>uhungarumlaut</string>
 	</array>
 	<key>@MMK_L_underscore</key>
 	<array>
-		<string>underscore'</string>
+		<string>underscore</string>
 	</array>
 	<key>@MMK_L_uogonek</key>
 	<array>
-		<string>uogonek'</string>
+		<string>uogonek</string>
 	</array>
 	<key>@MMK_L_utilde</key>
 	<array>
-		<string>utilde'</string>
+		<string>utilde</string>
 	</array>
 	<key>@MMK_L_v</key>
 	<array>
-		<string>v'</string>
+		<string>v</string>
 		<string>w</string>
 		<string>wcircumflex</string>
 	</array>
 	<key>@MMK_L_x</key>
 	<array>
-		<string>x'</string>
+		<string>x</string>
 	</array>
 	<key>@MMK_L_y</key>
 	<array>
-		<string>y'</string>
+		<string>y</string>
 	</array>
 	<key>@MMK_L_yacute</key>
 	<array>
-		<string>yacute'</string>
+		<string>yacute</string>
 	</array>
 	<key>@MMK_L_ycircumflex</key>
 	<array>
-		<string>ycircumflex'</string>
+		<string>ycircumflex</string>
 	</array>
 	<key>@MMK_L_ydieresis</key>
 	<array>
-		<string>ydieresis'</string>
+		<string>ydieresis</string>
 	</array>
 	<key>@MMK_L_yen</key>
 	<array>
-		<string>yen'</string>
+		<string>yen</string>
 	</array>
 	<key>@MMK_L_z</key>
 	<array>
-		<string>z'</string>
+		<string>z</string>
 		<string>zdotaccent</string>
 	</array>
 	<key>@MMK_L_zacute</key>
 	<array>
-		<string>zacute'</string>
+		<string>zacute</string>
 	</array>
 	<key>@MMK_L_zcaron</key>
 	<array>
-		<string>zcaron'</string>
+		<string>zcaron</string>
 	</array>
 	<key>@MMK_R_A</key>
 	<array>
-		<string>A'</string>
+		<string>A</string>
 		<string>Aacute</string>
 		<string>Abreve</string>
 		<string>Acircumflex</string>
@@ -1064,15 +1064,15 @@
 	</array>
 	<key>@MMK_R_AE</key>
 	<array>
-		<string>AE'</string>
+		<string>AE</string>
 	</array>
 	<key>@MMK_R_B</key>
 	<array>
-		<string>B'</string>
+		<string>B</string>
 	</array>
 	<key>@MMK_R_C</key>
 	<array>
-		<string>C'</string>
+		<string>C</string>
 		<string>Cacute</string>
 		<string>Ccaron</string>
 		<string>Ccedilla</string>
@@ -1102,7 +1102,7 @@
 	</array>
 	<key>@MMK_R_D</key>
 	<array>
-		<string>D'</string>
+		<string>D</string>
 		<string>Dcaron</string>
 		<string>Dcroat</string>
 		<string>Eth</string>
@@ -1116,7 +1116,7 @@
 	</array>
 	<key>@MMK_R_E</key>
 	<array>
-		<string>E'</string>
+		<string>E</string>
 		<string>Eacute</string>
 		<string>Ebreve</string>
 		<string>Ecaron</string>
@@ -1129,15 +1129,15 @@
 	</array>
 	<key>@MMK_R_Euro</key>
 	<array>
-		<string>Euro'</string>
+		<string>Euro</string>
 	</array>
 	<key>@MMK_R_F</key>
 	<array>
-		<string>F'</string>
+		<string>F</string>
 	</array>
 	<key>@MMK_R_H</key>
 	<array>
-		<string>H'</string>
+		<string>H</string>
 		<string>Hbar</string>
 		<string>Hcircumflex</string>
 		<string>I</string>
@@ -1157,37 +1157,37 @@
 	</array>
 	<key>@MMK_R_Idieresis</key>
 	<array>
-		<string>Idieresis'</string>
+		<string>Idieresis</string>
 	</array>
 	<key>@MMK_R_Iogonek</key>
 	<array>
-		<string>Iogonek'</string>
+		<string>Iogonek</string>
 	</array>
 	<key>@MMK_R_Itilde</key>
 	<array>
-		<string>Itilde'</string>
+		<string>Itilde</string>
 	</array>
 	<key>@MMK_R_J</key>
 	<array>
-		<string>J'</string>
+		<string>J</string>
 		<string>Jcircumflex</string>
 	</array>
 	<key>@MMK_R_J.001</key>
 	<array>
-		<string>J.001'</string>
+		<string>J.001</string>
 		<string>Jcircumflex.001</string>
 	</array>
 	<key>@MMK_R_Ldot</key>
 	<array>
-		<string>Ldot'</string>
+		<string>Ldot</string>
 	</array>
 	<key>@MMK_R_M</key>
 	<array>
-		<string>M'</string>
+		<string>M</string>
 	</array>
 	<key>@MMK_R_N</key>
 	<array>
-		<string>N'</string>
+		<string>N</string>
 		<string>Nacute</string>
 		<string>Ncaron</string>
 		<string>Ncommaaccent</string>
@@ -1195,15 +1195,15 @@
 	</array>
 	<key>@MMK_R_Q</key>
 	<array>
-		<string>Q'</string>
+		<string>Q</string>
 	</array>
 	<key>@MMK_R_Q_u</key>
 	<array>
-		<string>Q_u'</string>
+		<string>Q_u</string>
 	</array>
 	<key>@MMK_R_S</key>
 	<array>
-		<string>S'</string>
+		<string>S</string>
 		<string>Sacute</string>
 		<string>Scaron</string>
 		<string>Scedilla</string>
@@ -1212,29 +1212,29 @@
 	</array>
 	<key>@MMK_R_T</key>
 	<array>
-		<string>T'</string>
+		<string>T</string>
 		<string>Tcaron</string>
 		<string>Tcedilla</string>
 		<string>Tcommaaccent</string>
 	</array>
 	<key>@MMK_R_T.001</key>
 	<array>
-		<string>T.001'</string>
+		<string>T.001</string>
 		<string>Tcaron.001</string>
 		<string>Tcedilla.001</string>
 		<string>Tcommaaccent.001</string>
 	</array>
 	<key>@MMK_R_Tbar</key>
 	<array>
-		<string>Tbar'</string>
+		<string>Tbar</string>
 	</array>
 	<key>@MMK_R_Tbar.001</key>
 	<array>
-		<string>Tbar.001'</string>
+		<string>Tbar.001</string>
 	</array>
 	<key>@MMK_R_U</key>
 	<array>
-		<string>U'</string>
+		<string>U</string>
 		<string>Uacute</string>
 		<string>Ubreve</string>
 		<string>Ucircumflex</string>
@@ -1248,38 +1248,38 @@
 	</array>
 	<key>@MMK_R_V</key>
 	<array>
-		<string>V'</string>
+		<string>V</string>
 		<string>W</string>
 		<string>Wcircumflex</string>
 	</array>
 	<key>@MMK_R_X</key>
 	<array>
-		<string>X'</string>
+		<string>X</string>
 	</array>
 	<key>@MMK_R_Y</key>
 	<array>
-		<string>Y'</string>
+		<string>Y</string>
 		<string>Yacute</string>
 		<string>Ycircumflex</string>
 		<string>Ydieresis</string>
 	</array>
 	<key>@MMK_R_Y.001</key>
 	<array>
-		<string>Y.001'</string>
+		<string>Y.001</string>
 		<string>Yacute.001</string>
 		<string>Ycircumflex.001</string>
 		<string>Ydieresis.001</string>
 	</array>
 	<key>@MMK_R_Z</key>
 	<array>
-		<string>Z'</string>
+		<string>Z</string>
 		<string>Zacute</string>
 		<string>Zcaron</string>
 		<string>Zdotaccent</string>
 	</array>
 	<key>@MMK_R_a</key>
 	<array>
-		<string>a'</string>
+		<string>a</string>
 		<string>aacute</string>
 		<string>abreve</string>
 		<string>acircumflex</string>
@@ -1294,34 +1294,34 @@
 	</array>
 	<key>@MMK_R_ampersand</key>
 	<array>
-		<string>ampersand'</string>
+		<string>ampersand</string>
 	</array>
 	<key>@MMK_R_asciicircum</key>
 	<array>
-		<string>guillemotright.uppercase'</string>
+		<string>guillemotright.uppercase</string>
 		<string>guilsinglright.uppercase</string>
 		<string>asciicircum</string>
 	</array>
 	<key>@MMK_R_asterisk</key>
 	<array>
-		<string>asterisk'</string>
+		<string>asterisk</string>
 	</array>
 	<key>@MMK_R_at</key>
 	<array>
-		<string>at'</string>
+		<string>at</string>
 		<string>copyright</string>
 	</array>
 	<key>@MMK_R_b</key>
 	<array>
-		<string>b'</string>
+		<string>b</string>
 	</array>
 	<key>@MMK_R_backslash</key>
 	<array>
-		<string>backslash'</string>
+		<string>backslash</string>
 	</array>
 	<key>@MMK_R_bar</key>
 	<array>
-		<string>zero.lining'</string>
+		<string>zero.lining</string>
 		<string>one.lining</string>
 		<string>two.lining</string>
 		<string>three.lining</string>
@@ -1359,33 +1359,33 @@
 	</array>
 	<key>@MMK_R_braceright</key>
 	<array>
-		<string>braceright'</string>
+		<string>braceright</string>
 	</array>
 	<key>@MMK_R_braceright.uppercase</key>
 	<array>
-		<string>braceright.uppercase'</string>
+		<string>braceright.uppercase</string>
 	</array>
 	<key>@MMK_R_bracketleft</key>
 	<array>
-		<string>braceleft'</string>
+		<string>braceleft</string>
 		<string>bracketleft</string>
 	</array>
 	<key>@MMK_R_bracketleft.uppercase</key>
 	<array>
-		<string>braceleft.uppercase'</string>
+		<string>braceleft.uppercase</string>
 		<string>bracketleft.uppercase</string>
 	</array>
 	<key>@MMK_R_bracketright</key>
 	<array>
-		<string>bracketright'</string>
+		<string>bracketright</string>
 	</array>
 	<key>@MMK_R_bracketright.uppercase</key>
 	<array>
-		<string>bracketright.uppercase'</string>
+		<string>bracketright.uppercase</string>
 	</array>
 	<key>@MMK_R_bullet</key>
 	<array>
-		<string>bullet'</string>
+		<string>bullet</string>
 		<string>emdash.uppercase</string>
 		<string>endash.uppercase</string>
 		<string>figuredash.uppercase</string>
@@ -1397,11 +1397,11 @@
 	</array>
 	<key>@MMK_R_bullet.001</key>
 	<array>
-		<string>bullet.001'</string>
+		<string>bullet.001</string>
 	</array>
 	<key>@MMK_R_c</key>
 	<array>
-		<string>c'</string>
+		<string>c</string>
 		<string>cacute</string>
 		<string>ccaron</string>
 		<string>ccedilla</string>
@@ -1431,30 +1431,30 @@
 	</array>
 	<key>@MMK_R_colon</key>
 	<array>
-		<string>colon'</string>
+		<string>colon</string>
 		<string>semicolon</string>
 	</array>
 	<key>@MMK_R_comma</key>
 	<array>
-		<string>comma'</string>
+		<string>comma</string>
 	</array>
 	<key>@MMK_R_d</key>
 	<array>
-		<string>d'</string>
+		<string>d</string>
 		<string>dcaron</string>
 		<string>dcroat</string>
 	</array>
 	<key>@MMK_R_degree</key>
 	<array>
-		<string>degree'</string>
+		<string>degree</string>
 	</array>
 	<key>@MMK_R_dollar</key>
 	<array>
-		<string>dollar'</string>
+		<string>dollar</string>
 	</array>
 	<key>@MMK_R_dollar.lining.sub</key>
 	<array>
-		<string>zero.lining.sub'</string>
+		<string>zero.lining.sub</string>
 		<string>one.lining.sub</string>
 		<string>two.lining.sub</string>
 		<string>three.lining.sub</string>
@@ -1474,50 +1474,50 @@
 	</array>
 	<key>@MMK_R_dotlessi</key>
 	<array>
-		<string>dotlessi'</string>
+		<string>dotlessi</string>
 	</array>
 	<key>@MMK_R_dotlessj</key>
 	<array>
-		<string>dotlessj'</string>
+		<string>dotlessj</string>
 	</array>
 	<key>@MMK_R_eight</key>
 	<array>
-		<string>eight'</string>
+		<string>eight</string>
 	</array>
 	<key>@MMK_R_eth</key>
 	<array>
-		<string>eth'</string>
+		<string>eth</string>
 	</array>
 	<key>@MMK_R_exclam</key>
 	<array>
-		<string>exclam'</string>
+		<string>exclam</string>
 		<string>exclamdown</string>
 		<string>question</string>
 		<string>questiondown</string>
 	</array>
 	<key>@MMK_R_f</key>
 	<array>
-		<string>f'</string>
+		<string>f</string>
 		<string>florin</string>
 	</array>
 	<key>@MMK_R_f_f</key>
 	<array>
-		<string>f_f'</string>
+		<string>f_f</string>
 	</array>
 	<key>@MMK_R_f_f_i</key>
 	<array>
-		<string>f_f_i'</string>
+		<string>f_f_i</string>
 	</array>
 	<key>@MMK_R_f_f_l</key>
 	<array>
-		<string>f_f_b'</string>
+		<string>f_f_b</string>
 		<string>f_f_h</string>
 		<string>f_f_k</string>
 		<string>f_f_l</string>
 	</array>
 	<key>@MMK_R_f_i</key>
 	<array>
-		<string>f_b'</string>
+		<string>f_b</string>
 		<string>f_h</string>
 		<string>f_i</string>
 		<string>f_k</string>
@@ -1525,30 +1525,30 @@
 	</array>
 	<key>@MMK_R_five</key>
 	<array>
-		<string>five'</string>
+		<string>five</string>
 	</array>
 	<key>@MMK_R_four</key>
 	<array>
-		<string>four'</string>
+		<string>four</string>
 	</array>
 	<key>@MMK_R_g</key>
 	<array>
-		<string>g'</string>
+		<string>g</string>
 		<string>gcommaaccent</string>
 		<string>gdotaccent</string>
 	</array>
 	<key>@MMK_R_gcircumflex</key>
 	<array>
-		<string>gbreve'</string>
+		<string>gbreve</string>
 		<string>gcircumflex</string>
 	</array>
 	<key>@MMK_R_germandbls</key>
 	<array>
-		<string>germandbls'</string>
+		<string>germandbls</string>
 	</array>
 	<key>@MMK_R_grave</key>
 	<array>
-		<string>onequarter'</string>
+		<string>onequarter</string>
 		<string>onehalf</string>
 		<string>threequarters</string>
 		<string>zero.lining.numer</string>
@@ -1632,31 +1632,31 @@
 	</array>
 	<key>@MMK_R_guillemotleft</key>
 	<array>
-		<string>guillemotleft'</string>
+		<string>guillemotleft</string>
 		<string>guilsinglleft</string>
 	</array>
 	<key>@MMK_R_guillemotleft.uppercase</key>
 	<array>
-		<string>guillemotleft.uppercase'</string>
+		<string>guillemotleft.uppercase</string>
 		<string>guilsinglleft.uppercase</string>
 	</array>
 	<key>@MMK_R_guillemotright</key>
 	<array>
-		<string>guillemotright'</string>
+		<string>guillemotright</string>
 		<string>guilsinglright</string>
 	</array>
 	<key>@MMK_R_h</key>
 	<array>
-		<string>h'</string>
+		<string>h</string>
 		<string>hcircumflex</string>
 	</array>
 	<key>@MMK_R_hbar</key>
 	<array>
-		<string>hbar'</string>
+		<string>hbar</string>
 	</array>
 	<key>@MMK_R_hyphen</key>
 	<array>
-		<string>zero'</string>
+		<string>zero</string>
 		<string>fraction</string>
 		<string>emdash</string>
 		<string>endash</string>
@@ -1670,74 +1670,74 @@
 	</array>
 	<key>@MMK_R_i</key>
 	<array>
-		<string>i'</string>
+		<string>i</string>
 		<string>ij</string>
 		<string>i.TRK</string>
 	</array>
 	<key>@MMK_R_iacute</key>
 	<array>
-		<string>iacute'</string>
+		<string>iacute</string>
 	</array>
 	<key>@MMK_R_icircumflex</key>
 	<array>
-		<string>ibreve'</string>
+		<string>ibreve</string>
 		<string>icircumflex</string>
 	</array>
 	<key>@MMK_R_idieresis</key>
 	<array>
-		<string>idieresis'</string>
+		<string>idieresis</string>
 	</array>
 	<key>@MMK_R_igrave</key>
 	<array>
-		<string>igrave'</string>
+		<string>igrave</string>
 	</array>
 	<key>@MMK_R_imacron</key>
 	<array>
-		<string>imacron'</string>
+		<string>imacron</string>
 	</array>
 	<key>@MMK_R_iogonek</key>
 	<array>
-		<string>iogonek'</string>
+		<string>iogonek</string>
 	</array>
 	<key>@MMK_R_itilde</key>
 	<array>
-		<string>itilde'</string>
+		<string>itilde</string>
 	</array>
 	<key>@MMK_R_j</key>
 	<array>
-		<string>j'</string>
+		<string>j</string>
 	</array>
 	<key>@MMK_R_jcircumflex</key>
 	<array>
-		<string>jcircumflex'</string>
+		<string>jcircumflex</string>
 	</array>
 	<key>@MMK_R_k</key>
 	<array>
-		<string>k'</string>
+		<string>k</string>
 		<string>kcommaaccent</string>
 	</array>
 	<key>@MMK_R_l</key>
 	<array>
-		<string>l'</string>
+		<string>l</string>
 		<string>lacute</string>
 		<string>lcaron</string>
 		<string>lcommaaccent</string>
 	</array>
 	<key>@MMK_R_ldot</key>
 	<array>
-		<string>ldot'</string>
+		<string>ldot</string>
 	</array>
 	<key>@MMK_R_longs</key>
 	<array>
-		<string>longs'</string>
+		<string>longs</string>
 	</array>
 	<key>@MMK_R_lslash</key>
 	<array>
-		<string>lslash'</string>
+		<string>lslash</string>
 	</array>
 	<key>@MMK_R_m</key>
 	<array>
-		<string>m'</string>
+		<string>m</string>
 		<string>n</string>
 		<string>nacute</string>
 		<string>ncaron</string>
@@ -1746,78 +1746,78 @@
 	</array>
 	<key>@MMK_R_micro</key>
 	<array>
-		<string>micro'</string>
+		<string>micro</string>
 	</array>
 	<key>@MMK_R_napostrophe</key>
 	<array>
-		<string>napostrophe'</string>
+		<string>napostrophe</string>
 	</array>
 	<key>@MMK_R_nine</key>
 	<array>
-		<string>nine'</string>
+		<string>nine</string>
 	</array>
 	<key>@MMK_R_numbersign</key>
 	<array>
-		<string>numbersign'</string>
+		<string>numbersign</string>
 		<string>currency</string>
 	</array>
 	<key>@MMK_R_odieresis</key>
 	<array>
-		<string>odieresis'</string>
+		<string>odieresis</string>
 	</array>
 	<key>@MMK_R_one</key>
 	<array>
-		<string>one'</string>
+		<string>one</string>
 	</array>
 	<key>@MMK_R_ordfeminine</key>
 	<array>
-		<string>ordfeminine'</string>
+		<string>ordfeminine</string>
 		<string>ordmasculine</string>
 	</array>
 	<key>@MMK_R_otilde</key>
 	<array>
-		<string>otilde'</string>
+		<string>otilde</string>
 	</array>
 	<key>@MMK_R_p</key>
 	<array>
-		<string>p'</string>
+		<string>p</string>
 	</array>
 	<key>@MMK_R_paragraph</key>
 	<array>
-		<string>paragraph'</string>
+		<string>paragraph</string>
 	</array>
 	<key>@MMK_R_parenleft</key>
 	<array>
-		<string>parenleft'</string>
+		<string>parenleft</string>
 	</array>
 	<key>@MMK_R_parenleft.uppercase</key>
 	<array>
-		<string>parenleft.uppercase'</string>
+		<string>parenleft.uppercase</string>
 	</array>
 	<key>@MMK_R_parenright</key>
 	<array>
-		<string>parenright'</string>
+		<string>parenright</string>
 	</array>
 	<key>@MMK_R_parenright.uppercase</key>
 	<array>
-		<string>parenright.uppercase'</string>
+		<string>parenright.uppercase</string>
 	</array>
 	<key>@MMK_R_percent</key>
 	<array>
-		<string>percent'</string>
+		<string>percent</string>
 	</array>
 	<key>@MMK_R_period</key>
 	<array>
-		<string>ellipsis'</string>
+		<string>ellipsis</string>
 		<string>period</string>
 	</array>
 	<key>@MMK_R_periodcentered</key>
 	<array>
-		<string>periodcentered'</string>
+		<string>periodcentered</string>
 	</array>
 	<key>@MMK_R_plus</key>
 	<array>
-		<string>t'</string>
+		<string>t</string>
 		<string>tbar</string>
 		<string>tcaron</string>
 		<string>tcedilla</string>
@@ -1834,84 +1834,84 @@
 	</array>
 	<key>@MMK_R_quotedbl</key>
 	<array>
-		<string>quotedbl'</string>
+		<string>quotedbl</string>
 		<string>quotesingle</string>
 		<string>quotedblright</string>
 		<string>quoteright</string>
 	</array>
 	<key>@MMK_R_quoteleft</key>
 	<array>
-		<string>quotedblleft'</string>
+		<string>quotedblleft</string>
 		<string>quoteleft</string>
 		<string>quotereversed</string>
 		<string>uni201F</string>
 	</array>
 	<key>@MMK_R_quotesinglbase</key>
 	<array>
-		<string>quotedblbase'</string>
+		<string>quotedblbase</string>
 		<string>quotesinglbase</string>
 	</array>
 	<key>@MMK_R_r</key>
 	<array>
-		<string>r'</string>
+		<string>r</string>
 		<string>racute</string>
 		<string>rcommaaccent</string>
 	</array>
 	<key>@MMK_R_rcaron</key>
 	<array>
-		<string>rcaron'</string>
+		<string>rcaron</string>
 	</array>
 	<key>@MMK_R_registered</key>
 	<array>
-		<string>registered'</string>
+		<string>registered</string>
 	</array>
 	<key>@MMK_R_s</key>
 	<array>
-		<string>s'</string>
+		<string>s</string>
 		<string>sacute</string>
 		<string>scedilla</string>
 		<string>scommaaccent</string>
 	</array>
 	<key>@MMK_R_scircumflex</key>
 	<array>
-		<string>scaron'</string>
+		<string>scaron</string>
 		<string>scircumflex</string>
 	</array>
 	<key>@MMK_R_section</key>
 	<array>
-		<string>section'</string>
+		<string>section</string>
 	</array>
 	<key>@MMK_R_seven</key>
 	<array>
-		<string>seven'</string>
+		<string>seven</string>
 	</array>
 	<key>@MMK_R_six</key>
 	<array>
-		<string>six'</string>
+		<string>six</string>
 	</array>
 	<key>@MMK_R_slash</key>
 	<array>
-		<string>slash'</string>
+		<string>slash</string>
 	</array>
 	<key>@MMK_R_sterling</key>
 	<array>
-		<string>sterling'</string>
+		<string>sterling</string>
 	</array>
 	<key>@MMK_R_thorn</key>
 	<array>
-		<string>thorn'</string>
+		<string>thorn</string>
 	</array>
 	<key>@MMK_R_three</key>
 	<array>
-		<string>three'</string>
+		<string>three</string>
 	</array>
 	<key>@MMK_R_two</key>
 	<array>
-		<string>two'</string>
+		<string>two</string>
 	</array>
 	<key>@MMK_R_u</key>
 	<array>
-		<string>u'</string>
+		<string>u</string>
 		<string>uacute</string>
 		<string>ubreve</string>
 		<string>ucircumflex</string>
@@ -1925,35 +1925,35 @@
 	</array>
 	<key>@MMK_R_underscore</key>
 	<array>
-		<string>underscore'</string>
+		<string>underscore</string>
 	</array>
 	<key>@MMK_R_v</key>
 	<array>
-		<string>v'</string>
+		<string>v</string>
 		<string>w</string>
 		<string>wcircumflex</string>
 	</array>
 	<key>@MMK_R_x</key>
 	<array>
-		<string>x'</string>
+		<string>x</string>
 	</array>
 	<key>@MMK_R_y</key>
 	<array>
-		<string>y'</string>
+		<string>y</string>
 		<string>yacute</string>
 		<string>ycircumflex</string>
 	</array>
 	<key>@MMK_R_ydieresis</key>
 	<array>
-		<string>ydieresis'</string>
+		<string>ydieresis</string>
 	</array>
 	<key>@MMK_R_yen</key>
 	<array>
-		<string>yen'</string>
+		<string>yen</string>
 	</array>
 	<key>@MMK_R_z</key>
 	<array>
-		<string>z'</string>
+		<string>z</string>
 		<string>zacute</string>
 		<string>zcaron</string>
 		<string>zdotaccent</string>

--- a/source/OFLGoudyStM.ufo/groups.plist
+++ b/source/OFLGoudyStM.ufo/groups.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>@MMK_L_A</key>
 	<array>
-		<string>A'</string>
+		<string>A</string>
 		<string>Aacute</string>
 		<string>Abreve</string>
 		<string>Acircumflex</string>
@@ -17,11 +17,11 @@
 	</array>
 	<key>@MMK_L_B</key>
 	<array>
-		<string>B'</string>
+		<string>B</string>
 	</array>
 	<key>@MMK_L_C</key>
 	<array>
-		<string>C'</string>
+		<string>C</string>
 		<string>Cacute</string>
 		<string>Ccaron</string>
 		<string>Ccedilla</string>
@@ -30,46 +30,46 @@
 	</array>
 	<key>@MMK_L_D</key>
 	<array>
-		<string>D'</string>
+		<string>D</string>
 		<string>Dcaron</string>
 		<string>Dcroat</string>
 		<string>Eth</string>
 	</array>
 	<key>@MMK_L_Euro</key>
 	<array>
-		<string>Euro'</string>
+		<string>Euro</string>
 	</array>
 	<key>@MMK_L_F</key>
 	<array>
-		<string>F'</string>
+		<string>F</string>
 	</array>
 	<key>@MMK_L_K</key>
 	<array>
-		<string>K'</string>
+		<string>K</string>
 		<string>Kcommaaccent</string>
 	</array>
 	<key>@MMK_L_L</key>
 	<array>
-		<string>L'</string>
+		<string>L</string>
 		<string>Lacute</string>
 		<string>Lcaron</string>
 		<string>Lcommaaccent</string>
 	</array>
 	<key>@MMK_L_Ldot</key>
 	<array>
-		<string>Ldot'</string>
+		<string>Ldot</string>
 	</array>
 	<key>@MMK_L_Lslash</key>
 	<array>
-		<string>Lslash'</string>
+		<string>Lslash</string>
 	</array>
 	<key>@MMK_L_M</key>
 	<array>
-		<string>M'</string>
+		<string>M</string>
 	</array>
 	<key>@MMK_L_N</key>
 	<array>
-		<string>N'</string>
+		<string>N</string>
 		<string>Nacute</string>
 		<string>Ncaron</string>
 		<string>Ncommaaccent</string>
@@ -77,22 +77,22 @@
 	</array>
 	<key>@MMK_L_P</key>
 	<array>
-		<string>P'</string>
+		<string>P</string>
 	</array>
 	<key>@MMK_L_Q</key>
 	<array>
-		<string>Q'</string>
+		<string>Q</string>
 	</array>
 	<key>@MMK_L_R</key>
 	<array>
-		<string>R'</string>
+		<string>R</string>
 		<string>Racute</string>
 		<string>Rcaron</string>
 		<string>Rcommaaccent</string>
 	</array>
 	<key>@MMK_L_S</key>
 	<array>
-		<string>S'</string>
+		<string>S</string>
 		<string>Sacute</string>
 		<string>Scaron</string>
 		<string>Scedilla</string>
@@ -101,22 +101,22 @@
 	</array>
 	<key>@MMK_L_T</key>
 	<array>
-		<string>T'</string>
+		<string>T</string>
 		<string>Tcaron</string>
 		<string>Tcedilla</string>
 		<string>Tcommaaccent</string>
 	</array>
 	<key>@MMK_L_Tbar</key>
 	<array>
-		<string>Tbar'</string>
+		<string>Tbar</string>
 	</array>
 	<key>@MMK_L_Thorn</key>
 	<array>
-		<string>Thorn'</string>
+		<string>Thorn</string>
 	</array>
 	<key>@MMK_L_U</key>
 	<array>
-		<string>U'</string>
+		<string>U</string>
 		<string>Uacute</string>
 		<string>Ubreve</string>
 		<string>Ucircumflex</string>
@@ -130,34 +130,34 @@
 	</array>
 	<key>@MMK_L_V</key>
 	<array>
-		<string>V'</string>
+		<string>V</string>
 	</array>
 	<key>@MMK_L_W</key>
 	<array>
-		<string>W'</string>
+		<string>W</string>
 		<string>Wcircumflex</string>
 	</array>
 	<key>@MMK_L_X</key>
 	<array>
-		<string>X'</string>
+		<string>X</string>
 	</array>
 	<key>@MMK_L_Y</key>
 	<array>
-		<string>Y'</string>
+		<string>Y</string>
 		<string>Yacute</string>
 		<string>Ycircumflex</string>
 		<string>Ydieresis</string>
 	</array>
 	<key>@MMK_L_Z</key>
 	<array>
-		<string>Z'</string>
+		<string>Z</string>
 		<string>Zacute</string>
 		<string>Zcaron</string>
 		<string>Zdotaccent</string>
 	</array>
 	<key>@MMK_L_a</key>
 	<array>
-		<string>a'</string>
+		<string>a</string>
 		<string>acircumflex</string>
 		<string>agrave</string>
 		<string>amacron</string>
@@ -165,7 +165,7 @@
 	</array>
 	<key>@MMK_L_a.sc</key>
 	<array>
-		<string>a.sc'</string>
+		<string>a.sc</string>
 		<string>aacute.sc</string>
 		<string>abreve.sc</string>
 		<string>acircumflex.sc</string>
@@ -178,41 +178,41 @@
 	</array>
 	<key>@MMK_L_aacute</key>
 	<array>
-		<string>aacute'</string>
+		<string>aacute</string>
 	</array>
 	<key>@MMK_L_abreve</key>
 	<array>
-		<string>abreve'</string>
+		<string>abreve</string>
 	</array>
 	<key>@MMK_L_adieresis</key>
 	<array>
-		<string>adieresis'</string>
+		<string>adieresis</string>
 	</array>
 	<key>@MMK_L_ampersand</key>
 	<array>
-		<string>ampersand'</string>
+		<string>ampersand</string>
 	</array>
 	<key>@MMK_L_ampersand.sc</key>
 	<array>
-		<string>ampersand.sc'</string>
+		<string>ampersand.sc</string>
 	</array>
 	<key>@MMK_L_aogonek</key>
 	<array>
-		<string>aogonek'</string>
+		<string>aogonek</string>
 	</array>
 	<key>@MMK_L_asciicircum</key>
 	<array>
-		<string>guillemotleft.uppercase'</string>
+		<string>guillemotleft.uppercase</string>
 		<string>guilsinglleft.uppercase</string>
 		<string>asciicircum</string>
 	</array>
 	<key>@MMK_L_asterisk</key>
 	<array>
-		<string>asterisk'</string>
+		<string>asterisk</string>
 	</array>
 	<key>@MMK_L_at</key>
 	<array>
-		<string>O'</string>
+		<string>O</string>
 		<string>Oacute</string>
 		<string>Obreve</string>
 		<string>Ocircumflex</string>
@@ -227,26 +227,26 @@
 	</array>
 	<key>@MMK_L_atilde</key>
 	<array>
-		<string>atilde'</string>
+		<string>atilde</string>
 	</array>
 	<key>@MMK_L_b.sc</key>
 	<array>
-		<string>b.sc'</string>
+		<string>b.sc</string>
 	</array>
 	<key>@MMK_L_backslash</key>
 	<array>
-		<string>backslash'</string>
+		<string>backslash</string>
 	</array>
 	<key>@MMK_L_bracketleft</key>
 	<array>
-		<string>braceleft'</string>
+		<string>braceleft</string>
 		<string>bracketleft</string>
 		<string>braceleft.uppercase</string>
 		<string>bracketleft.uppercase</string>
 	</array>
 	<key>@MMK_L_bracketright</key>
 	<array>
-		<string>Eogonek'</string>
+		<string>Eogonek</string>
 		<string>Hbar</string>
 		<string>zero.lining.sup</string>
 		<string>one.lining.sup</string>
@@ -279,43 +279,43 @@
 	</array>
 	<key>@MMK_L_c_t</key>
 	<array>
-		<string>c_t'</string>
+		<string>c_t</string>
 	</array>
 	<key>@MMK_L_cacute</key>
 	<array>
-		<string>cacute'</string>
+		<string>cacute</string>
 	</array>
 	<key>@MMK_L_ccaron</key>
 	<array>
-		<string>ccaron'</string>
+		<string>ccaron</string>
 	</array>
 	<key>@MMK_L_ccircumflex</key>
 	<array>
-		<string>ccircumflex'</string>
+		<string>ccircumflex</string>
 	</array>
 	<key>@MMK_L_comma</key>
 	<array>
-		<string>comma'</string>
+		<string>comma</string>
 	</array>
 	<key>@MMK_L_d</key>
 	<array>
-		<string>d'</string>
+		<string>d</string>
 	</array>
 	<key>@MMK_L_dcaron</key>
 	<array>
-		<string>dcaron'</string>
+		<string>dcaron</string>
 	</array>
 	<key>@MMK_L_dcroat</key>
 	<array>
-		<string>dcroat'</string>
+		<string>dcroat</string>
 	</array>
 	<key>@MMK_L_degree</key>
 	<array>
-		<string>degree'</string>
+		<string>degree</string>
 	</array>
 	<key>@MMK_L_dollar.lining.sub</key>
 	<array>
-		<string>zero.lining.sub'</string>
+		<string>zero.lining.sub</string>
 		<string>one.lining.sub</string>
 		<string>two.lining.sub</string>
 		<string>three.lining.sub</string>
@@ -335,15 +335,15 @@
 	</array>
 	<key>@MMK_L_dotlessi</key>
 	<array>
-		<string>dotlessi'</string>
+		<string>dotlessi</string>
 	</array>
 	<key>@MMK_L_dotlessj</key>
 	<array>
-		<string>dotlessj'</string>
+		<string>dotlessj</string>
 	</array>
 	<key>@MMK_L_e</key>
 	<array>
-		<string>ae'</string>
+		<string>ae</string>
 		<string>e</string>
 		<string>ecaron</string>
 		<string>ecircumflex</string>
@@ -354,7 +354,7 @@
 	</array>
 	<key>@MMK_L_e.sc</key>
 	<array>
-		<string>ae.sc'</string>
+		<string>ae.sc</string>
 		<string>e.sc</string>
 		<string>eacute.sc</string>
 		<string>ebreve.sc</string>
@@ -368,35 +368,35 @@
 	</array>
 	<key>@MMK_L_eacute</key>
 	<array>
-		<string>eacute'</string>
+		<string>eacute</string>
 	</array>
 	<key>@MMK_L_ebreve</key>
 	<array>
-		<string>ebreve'</string>
+		<string>ebreve</string>
 	</array>
 	<key>@MMK_L_edieresis</key>
 	<array>
-		<string>edieresis'</string>
+		<string>edieresis</string>
 	</array>
 	<key>@MMK_L_eight</key>
 	<array>
-		<string>eight'</string>
+		<string>eight</string>
 	</array>
 	<key>@MMK_L_eogonek</key>
 	<array>
-		<string>eogonek'</string>
+		<string>eogonek</string>
 	</array>
 	<key>@MMK_L_eogonek.sc</key>
 	<array>
-		<string>eogonek.sc'</string>
+		<string>eogonek.sc</string>
 	</array>
 	<key>@MMK_L_eth</key>
 	<array>
-		<string>eth'</string>
+		<string>eth</string>
 	</array>
 	<key>@MMK_L_exclam</key>
 	<array>
-		<string>AE'</string>
+		<string>AE</string>
 		<string>E</string>
 		<string>Eacute</string>
 		<string>Ebreve</string>
@@ -447,50 +447,50 @@
 	</array>
 	<key>@MMK_L_f</key>
 	<array>
-		<string>f'</string>
+		<string>f</string>
 		<string>f_f</string>
 	</array>
 	<key>@MMK_L_f.sc</key>
 	<array>
-		<string>f.sc'</string>
+		<string>f.sc</string>
 	</array>
 	<key>@MMK_L_f_f_h</key>
 	<array>
-		<string>f_f_h'</string>
+		<string>f_f_h</string>
 	</array>
 	<key>@MMK_L_f_f_i</key>
 	<array>
-		<string>f_f_i'</string>
+		<string>f_f_i</string>
 	</array>
 	<key>@MMK_L_f_f_j</key>
 	<array>
-		<string>f_f_j'</string>
+		<string>f_f_j</string>
 	</array>
 	<key>@MMK_L_f_f_l</key>
 	<array>
-		<string>f_f_l'</string>
+		<string>f_f_l</string>
 	</array>
 	<key>@MMK_L_f_i</key>
 	<array>
-		<string>f_i'</string>
+		<string>f_i</string>
 	</array>
 	<key>@MMK_L_f_j</key>
 	<array>
-		<string>f_j'</string>
+		<string>f_j</string>
 	</array>
 	<key>@MMK_L_five</key>
 	<array>
-		<string>j.sc'</string>
+		<string>j.sc</string>
 		<string>jcircumflex.sc</string>
 		<string>five</string>
 	</array>
 	<key>@MMK_L_florin</key>
 	<array>
-		<string>florin'</string>
+		<string>florin</string>
 	</array>
 	<key>@MMK_L_g</key>
 	<array>
-		<string>g'</string>
+		<string>g</string>
 		<string>gbreve</string>
 		<string>gcircumflex</string>
 		<string>gcommaaccent</string>
@@ -498,7 +498,7 @@
 	</array>
 	<key>@MMK_L_g.sc</key>
 	<array>
-		<string>g.sc'</string>
+		<string>g.sc</string>
 		<string>gbreve.sc</string>
 		<string>gcircumflex.sc</string>
 		<string>gcommaaccent.sc</string>
@@ -506,11 +506,11 @@
 	</array>
 	<key>@MMK_L_germandbls</key>
 	<array>
-		<string>germandbls'</string>
+		<string>germandbls</string>
 	</array>
 	<key>@MMK_L_grave</key>
 	<array>
-		<string>onequarter'</string>
+		<string>onequarter</string>
 		<string>onehalf</string>
 		<string>threequarters</string>
 		<string>zero.lining.numer</string>
@@ -593,39 +593,39 @@
 	</array>
 	<key>@MMK_L_guillemotright</key>
 	<array>
-		<string>guillemotright'</string>
+		<string>guillemotright</string>
 	</array>
 	<key>@MMK_L_guillemotright.uppercase</key>
 	<array>
-		<string>guillemotright.uppercase'</string>
+		<string>guillemotright.uppercase</string>
 	</array>
 	<key>@MMK_L_guilsinglright</key>
 	<array>
-		<string>guilsinglright'</string>
+		<string>guilsinglright</string>
 	</array>
 	<key>@MMK_L_guilsinglright.uppercase</key>
 	<array>
-		<string>guilsinglright.uppercase'</string>
+		<string>guilsinglright.uppercase</string>
 	</array>
 	<key>@MMK_L_h</key>
 	<array>
-		<string>h'</string>
+		<string>h</string>
 		<string>hbar</string>
 		<string>hcircumflex</string>
 		<string>f_h</string>
 	</array>
 	<key>@MMK_L_h.sc</key>
 	<array>
-		<string>h.sc'</string>
+		<string>h.sc</string>
 		<string>hcircumflex.sc</string>
 	</array>
 	<key>@MMK_L_hbar.sc</key>
 	<array>
-		<string>hbar.sc'</string>
+		<string>hbar.sc</string>
 	</array>
 	<key>@MMK_L_hyphen</key>
 	<array>
-		<string>b'</string>
+		<string>b</string>
 		<string>c</string>
 		<string>ccedilla</string>
 		<string>cdotaccent</string>
@@ -673,141 +673,141 @@
 	</array>
 	<key>@MMK_L_i</key>
 	<array>
-		<string>i'</string>
+		<string>i</string>
 		<string>i.TRK</string>
 	</array>
 	<key>@MMK_L_i.sc</key>
 	<array>
-		<string>i.TRK.sc'</string>
+		<string>i.TRK.sc</string>
 		<string>i.sc</string>
 		<string>igrave.sc</string>
 	</array>
 	<key>@MMK_L_iacute</key>
 	<array>
-		<string>iacute'</string>
+		<string>iacute</string>
 	</array>
 	<key>@MMK_L_iacute.sc</key>
 	<array>
-		<string>iacute.sc'</string>
+		<string>iacute.sc</string>
 	</array>
 	<key>@MMK_L_ibreve</key>
 	<array>
-		<string>ibreve'</string>
+		<string>ibreve</string>
 	</array>
 	<key>@MMK_L_ibreve.sc</key>
 	<array>
-		<string>ibreve.sc'</string>
+		<string>ibreve.sc</string>
 	</array>
 	<key>@MMK_L_icircumflex</key>
 	<array>
-		<string>icircumflex'</string>
+		<string>icircumflex</string>
 	</array>
 	<key>@MMK_L_icircumflex.sc</key>
 	<array>
-		<string>icircumflex.sc'</string>
+		<string>icircumflex.sc</string>
 	</array>
 	<key>@MMK_L_idieresis</key>
 	<array>
-		<string>idieresis'</string>
+		<string>idieresis</string>
 	</array>
 	<key>@MMK_L_igrave</key>
 	<array>
-		<string>igrave'</string>
+		<string>igrave</string>
 	</array>
 	<key>@MMK_L_imacron</key>
 	<array>
-		<string>imacron'</string>
+		<string>imacron</string>
 	</array>
 	<key>@MMK_L_imacron.sc</key>
 	<array>
-		<string>imacron.sc'</string>
+		<string>imacron.sc</string>
 	</array>
 	<key>@MMK_L_iogonek</key>
 	<array>
-		<string>iogonek'</string>
+		<string>iogonek</string>
 	</array>
 	<key>@MMK_L_iogonek.sc</key>
 	<array>
-		<string>iogonek.sc'</string>
+		<string>iogonek.sc</string>
 	</array>
 	<key>@MMK_L_itilde</key>
 	<array>
-		<string>itilde'</string>
+		<string>itilde</string>
 	</array>
 	<key>@MMK_L_itilde.sc</key>
 	<array>
-		<string>idieresis.sc'</string>
+		<string>idieresis.sc</string>
 		<string>itilde.sc</string>
 	</array>
 	<key>@MMK_L_j</key>
 	<array>
-		<string>ij'</string>
+		<string>ij</string>
 		<string>j</string>
 	</array>
 	<key>@MMK_L_jcircumflex</key>
 	<array>
-		<string>jcircumflex'</string>
+		<string>jcircumflex</string>
 	</array>
 	<key>@MMK_L_k</key>
 	<array>
-		<string>k'</string>
+		<string>k</string>
 		<string>kcommaaccent</string>
 		<string>f_f_k</string>
 		<string>f_k</string>
 	</array>
 	<key>@MMK_L_k.sc</key>
 	<array>
-		<string>k.sc'</string>
+		<string>k.sc</string>
 		<string>kcommaaccent.sc</string>
 	</array>
 	<key>@MMK_L_l</key>
 	<array>
-		<string>l'</string>
+		<string>l</string>
 		<string>lacute</string>
 		<string>lcommaaccent</string>
 	</array>
 	<key>@MMK_L_l.sc</key>
 	<array>
-		<string>l.sc'</string>
+		<string>l.sc</string>
 		<string>lacute.sc</string>
 		<string>lcaron.sc</string>
 		<string>lcommaaccent.sc</string>
 	</array>
 	<key>@MMK_L_lcaron</key>
 	<array>
-		<string>lcaron'</string>
+		<string>lcaron</string>
 	</array>
 	<key>@MMK_L_ldot</key>
 	<array>
-		<string>ldot'</string>
+		<string>ldot</string>
 	</array>
 	<key>@MMK_L_ldot.sc</key>
 	<array>
-		<string>ldot.sc'</string>
+		<string>ldot.sc</string>
 	</array>
 	<key>@MMK_L_longs</key>
 	<array>
-		<string>longs'</string>
+		<string>longs</string>
 	</array>
 	<key>@MMK_L_lslash</key>
 	<array>
-		<string>lslash'</string>
+		<string>lslash</string>
 	</array>
 	<key>@MMK_L_lslash.sc</key>
 	<array>
-		<string>lslash.sc'</string>
+		<string>lslash.sc</string>
 	</array>
 	<key>@MMK_L_m</key>
 	<array>
-		<string>m'</string>
+		<string>m</string>
 	</array>
 	<key>@MMK_L_m.sc</key>
 	<array>
-		<string>m.sc'</string>
+		<string>m.sc</string>
 	</array>
 	<key>@MMK_L_n</key>
 	<array>
-		<string>n'</string>
+		<string>n</string>
 		<string>nacute</string>
 		<string>napostrophe</string>
 		<string>ncaron</string>
@@ -816,7 +816,7 @@
 	</array>
 	<key>@MMK_L_n.sc</key>
 	<array>
-		<string>n.sc'</string>
+		<string>n.sc</string>
 		<string>nacute.sc</string>
 		<string>ncaron.sc</string>
 		<string>ncommaaccent.sc</string>
@@ -824,67 +824,67 @@
 	</array>
 	<key>@MMK_L_nine</key>
 	<array>
-		<string>nine'</string>
+		<string>nine</string>
 	</array>
 	<key>@MMK_L_numbersign</key>
 	<array>
-		<string>numbersign'</string>
+		<string>numbersign</string>
 		<string>currency</string>
 	</array>
 	<key>@MMK_L_ohungarumlaut</key>
 	<array>
-		<string>ohungarumlaut'</string>
+		<string>ohungarumlaut</string>
 	</array>
 	<key>@MMK_L_one</key>
 	<array>
-		<string>one'</string>
+		<string>one</string>
 		<string>colon</string>
 	</array>
 	<key>@MMK_L_ordfeminine</key>
 	<array>
-		<string>ordfeminine'</string>
+		<string>ordfeminine</string>
 	</array>
 	<key>@MMK_L_ordmasculine</key>
 	<array>
-		<string>ordmasculine'</string>
+		<string>ordmasculine</string>
 	</array>
 	<key>@MMK_L_p.sc</key>
 	<array>
-		<string>p.sc'</string>
+		<string>p.sc</string>
 	</array>
 	<key>@MMK_L_paragraph</key>
 	<array>
-		<string>Iogonek'</string>
+		<string>Iogonek</string>
 		<string>paragraph</string>
 	</array>
 	<key>@MMK_L_parenleft</key>
 	<array>
-		<string>parenleft'</string>
+		<string>parenleft</string>
 	</array>
 	<key>@MMK_L_parenleft.uppercase</key>
 	<array>
-		<string>parenleft.uppercase'</string>
+		<string>parenleft.uppercase</string>
 	</array>
 	<key>@MMK_L_parenright</key>
 	<array>
-		<string>parenright'</string>
+		<string>parenright</string>
 	</array>
 	<key>@MMK_L_parenright.uppercase</key>
 	<array>
-		<string>parenright.uppercase'</string>
+		<string>parenright.uppercase</string>
 	</array>
 	<key>@MMK_L_percent</key>
 	<array>
-		<string>percent'</string>
+		<string>percent</string>
 	</array>
 	<key>@MMK_L_period</key>
 	<array>
-		<string>ellipsis'</string>
+		<string>ellipsis</string>
 		<string>period</string>
 	</array>
 	<key>@MMK_L_periodcentered</key>
 	<array>
-		<string>bullet'</string>
+		<string>bullet</string>
 		<string>periodcentered</string>
 		<string>emdash.uppercase</string>
 		<string>endash.uppercase</string>
@@ -897,7 +897,7 @@
 	</array>
 	<key>@MMK_L_plus</key>
 	<array>
-		<string>s'</string>
+		<string>s</string>
 		<string>scedilla</string>
 		<string>t</string>
 		<string>tbar</string>
@@ -936,64 +936,64 @@
 	</array>
 	<key>@MMK_L_q</key>
 	<array>
-		<string>q'</string>
+		<string>q</string>
 	</array>
 	<key>@MMK_L_q.sc</key>
 	<array>
-		<string>q.sc'</string>
+		<string>q.sc</string>
 	</array>
 	<key>@MMK_L_quotedbl</key>
 	<array>
-		<string>quotedbl'</string>
+		<string>quotedbl</string>
 		<string>quotedblright</string>
 	</array>
 	<key>@MMK_L_quotedblleft</key>
 	<array>
-		<string>quotedblleft'</string>
+		<string>quotedblleft</string>
 		<string>uni201F</string>
 	</array>
 	<key>@MMK_L_quoteleft</key>
 	<array>
-		<string>quoteleft'</string>
+		<string>quoteleft</string>
 		<string>quotereversed</string>
 	</array>
 	<key>@MMK_L_quotesinglbase</key>
 	<array>
-		<string>quotedblbase'</string>
+		<string>quotedblbase</string>
 		<string>quotesinglbase</string>
 	</array>
 	<key>@MMK_L_quotesingle</key>
 	<array>
-		<string>quotesingle'</string>
+		<string>quotesingle</string>
 		<string>quoteright</string>
 	</array>
 	<key>@MMK_L_r</key>
 	<array>
-		<string>r'</string>
+		<string>r</string>
 		<string>rcommaaccent</string>
 	</array>
 	<key>@MMK_L_r.sc</key>
 	<array>
-		<string>r.sc'</string>
+		<string>r.sc</string>
 		<string>racute.sc</string>
 		<string>rcaron.sc</string>
 		<string>rcommaaccent.sc</string>
 	</array>
 	<key>@MMK_L_racute</key>
 	<array>
-		<string>racute'</string>
+		<string>racute</string>
 	</array>
 	<key>@MMK_L_rcaron</key>
 	<array>
-		<string>rcaron'</string>
+		<string>rcaron</string>
 	</array>
 	<key>@MMK_L_registered</key>
 	<array>
-		<string>registered'</string>
+		<string>registered</string>
 	</array>
 	<key>@MMK_L_s.sc</key>
 	<array>
-		<string>s.sc'</string>
+		<string>s.sc</string>
 		<string>sacute.sc</string>
 		<string>scaron.sc</string>
 		<string>scedilla.sc</string>
@@ -1002,43 +1002,43 @@
 	</array>
 	<key>@MMK_L_sacute</key>
 	<array>
-		<string>sacute'</string>
+		<string>sacute</string>
 	</array>
 	<key>@MMK_L_scaron</key>
 	<array>
-		<string>scaron'</string>
+		<string>scaron</string>
 	</array>
 	<key>@MMK_L_scircumflex</key>
 	<array>
-		<string>scircumflex'</string>
+		<string>scircumflex</string>
 	</array>
 	<key>@MMK_L_section</key>
 	<array>
-		<string>section'</string>
+		<string>section</string>
 	</array>
 	<key>@MMK_L_semicolon</key>
 	<array>
-		<string>semicolon'</string>
+		<string>semicolon</string>
 	</array>
 	<key>@MMK_L_seven</key>
 	<array>
-		<string>seven'</string>
+		<string>seven</string>
 	</array>
 	<key>@MMK_L_six</key>
 	<array>
-		<string>six'</string>
+		<string>six</string>
 	</array>
 	<key>@MMK_L_slash</key>
 	<array>
-		<string>slash'</string>
+		<string>slash</string>
 	</array>
 	<key>@MMK_L_sterling</key>
 	<array>
-		<string>sterling'</string>
+		<string>sterling</string>
 	</array>
 	<key>@MMK_L_t.sc</key>
 	<array>
-		<string>t.sc'</string>
+		<string>t.sc</string>
 		<string>tbar.sc</string>
 		<string>tcaron.sc</string>
 		<string>tcedilla.sc</string>
@@ -1046,16 +1046,16 @@
 	</array>
 	<key>@MMK_L_three</key>
 	<array>
-		<string>three'</string>
+		<string>three</string>
 		<string>four</string>
 	</array>
 	<key>@MMK_L_two</key>
 	<array>
-		<string>two'</string>
+		<string>two</string>
 	</array>
 	<key>@MMK_L_u.sc</key>
 	<array>
-		<string>u.sc'</string>
+		<string>u.sc</string>
 		<string>uacute.sc</string>
 		<string>ubreve.sc</string>
 		<string>ucircumflex.sc</string>
@@ -1069,85 +1069,85 @@
 	</array>
 	<key>@MMK_L_uhungarumlaut</key>
 	<array>
-		<string>uhungarumlaut'</string>
+		<string>uhungarumlaut</string>
 	</array>
 	<key>@MMK_L_underscore</key>
 	<array>
-		<string>underscore'</string>
+		<string>underscore</string>
 	</array>
 	<key>@MMK_L_uogonek</key>
 	<array>
-		<string>uogonek'</string>
+		<string>uogonek</string>
 	</array>
 	<key>@MMK_L_v</key>
 	<array>
-		<string>v'</string>
+		<string>v</string>
 	</array>
 	<key>@MMK_L_v.sc</key>
 	<array>
-		<string>v.sc'</string>
+		<string>v.sc</string>
 		<string>w.sc</string>
 		<string>wcircumflex.sc</string>
 	</array>
 	<key>@MMK_L_w</key>
 	<array>
-		<string>w'</string>
+		<string>w</string>
 		<string>wcircumflex</string>
 	</array>
 	<key>@MMK_L_x</key>
 	<array>
-		<string>x'</string>
+		<string>x</string>
 	</array>
 	<key>@MMK_L_x.sc</key>
 	<array>
-		<string>x.sc'</string>
+		<string>x.sc</string>
 	</array>
 	<key>@MMK_L_y</key>
 	<array>
-		<string>y'</string>
+		<string>y</string>
 		<string>ycircumflex</string>
 	</array>
 	<key>@MMK_L_y.sc</key>
 	<array>
-		<string>y.sc'</string>
+		<string>y.sc</string>
 		<string>yacute.sc</string>
 		<string>ycircumflex.sc</string>
 		<string>ydieresis.sc</string>
 	</array>
 	<key>@MMK_L_yacute</key>
 	<array>
-		<string>yacute'</string>
+		<string>yacute</string>
 	</array>
 	<key>@MMK_L_ydieresis</key>
 	<array>
-		<string>ydieresis'</string>
+		<string>ydieresis</string>
 	</array>
 	<key>@MMK_L_yen</key>
 	<array>
-		<string>yen'</string>
+		<string>yen</string>
 	</array>
 	<key>@MMK_L_z.sc</key>
 	<array>
-		<string>z.sc'</string>
+		<string>z.sc</string>
 		<string>zacute.sc</string>
 		<string>zcaron.sc</string>
 		<string>zdotaccent.sc</string>
 	</array>
 	<key>@MMK_L_zacute</key>
 	<array>
-		<string>zacute'</string>
+		<string>zacute</string>
 	</array>
 	<key>@MMK_L_zcaron</key>
 	<array>
-		<string>zcaron'</string>
+		<string>zcaron</string>
 	</array>
 	<key>@MMK_L_zdotaccent</key>
 	<array>
-		<string>zdotaccent'</string>
+		<string>zdotaccent</string>
 	</array>
 	<key>@MMK_R_A</key>
 	<array>
-		<string>A'</string>
+		<string>A</string>
 		<string>Aacute</string>
 		<string>Abreve</string>
 		<string>Acircumflex</string>
@@ -1160,24 +1160,24 @@
 	</array>
 	<key>@MMK_R_AE</key>
 	<array>
-		<string>AE'</string>
+		<string>AE</string>
 	</array>
 	<key>@MMK_R_Euro</key>
 	<array>
-		<string>Euro'</string>
+		<string>Euro</string>
 	</array>
 	<key>@MMK_R_J</key>
 	<array>
-		<string>J'</string>
+		<string>J</string>
 		<string>Jcircumflex</string>
 	</array>
 	<key>@MMK_R_Ldot</key>
 	<array>
-		<string>Ldot'</string>
+		<string>Ldot</string>
 	</array>
 	<key>@MMK_R_M</key>
 	<array>
-		<string>M'</string>
+		<string>M</string>
 		<string>N</string>
 		<string>Nacute</string>
 		<string>Ncaron</string>
@@ -1186,11 +1186,11 @@
 	</array>
 	<key>@MMK_R_Q</key>
 	<array>
-		<string>Q'</string>
+		<string>Q</string>
 	</array>
 	<key>@MMK_R_S</key>
 	<array>
-		<string>S'</string>
+		<string>S</string>
 		<string>Sacute</string>
 		<string>Scaron</string>
 		<string>Scedilla</string>
@@ -1199,18 +1199,18 @@
 	</array>
 	<key>@MMK_R_T</key>
 	<array>
-		<string>T'</string>
+		<string>T</string>
 		<string>Tcaron</string>
 		<string>Tcedilla</string>
 		<string>Tcommaaccent</string>
 	</array>
 	<key>@MMK_R_Tbar</key>
 	<array>
-		<string>Tbar'</string>
+		<string>Tbar</string>
 	</array>
 	<key>@MMK_R_U</key>
 	<array>
-		<string>U'</string>
+		<string>U</string>
 		<string>Uacute</string>
 		<string>Ubreve</string>
 		<string>Ucircumflex</string>
@@ -1224,66 +1224,66 @@
 	</array>
 	<key>@MMK_R_V</key>
 	<array>
-		<string>V'</string>
+		<string>V</string>
 	</array>
 	<key>@MMK_R_W</key>
 	<array>
-		<string>W'</string>
+		<string>W</string>
 		<string>Wcircumflex</string>
 	</array>
 	<key>@MMK_R_X</key>
 	<array>
-		<string>X'</string>
+		<string>X</string>
 	</array>
 	<key>@MMK_R_Y</key>
 	<array>
-		<string>Y'</string>
+		<string>Y</string>
 		<string>Yacute</string>
 		<string>Ycircumflex</string>
 		<string>Ydieresis</string>
 	</array>
 	<key>@MMK_R_abreve</key>
 	<array>
-		<string>abreve'</string>
+		<string>abreve</string>
 		<string>scircumflex</string>
 	</array>
 	<key>@MMK_R_adieresis</key>
 	<array>
-		<string>adieresis'</string>
+		<string>adieresis</string>
 	</array>
 	<key>@MMK_R_ae.sc</key>
 	<array>
-		<string>ae.sc'</string>
+		<string>ae.sc</string>
 	</array>
 	<key>@MMK_R_agrave</key>
 	<array>
-		<string>agrave'</string>
+		<string>agrave</string>
 	</array>
 	<key>@MMK_R_amacron</key>
 	<array>
-		<string>amacron'</string>
+		<string>amacron</string>
 	</array>
 	<key>@MMK_R_ampersand</key>
 	<array>
-		<string>ampersand'</string>
+		<string>ampersand</string>
 	</array>
 	<key>@MMK_R_ampersand.sc</key>
 	<array>
-		<string>ampersand.sc'</string>
+		<string>ampersand.sc</string>
 	</array>
 	<key>@MMK_R_asciicircum</key>
 	<array>
-		<string>guillemotright.uppercase'</string>
+		<string>guillemotright.uppercase</string>
 		<string>guilsinglright.uppercase</string>
 		<string>asciicircum</string>
 	</array>
 	<key>@MMK_R_asterisk</key>
 	<array>
-		<string>asterisk'</string>
+		<string>asterisk</string>
 	</array>
 	<key>@MMK_R_at</key>
 	<array>
-		<string>C'</string>
+		<string>C</string>
 		<string>Cacute</string>
 		<string>Ccaron</string>
 		<string>Ccedilla</string>
@@ -1310,15 +1310,15 @@
 	</array>
 	<key>@MMK_R_atilde</key>
 	<array>
-		<string>atilde'</string>
+		<string>atilde</string>
 	</array>
 	<key>@MMK_R_b</key>
 	<array>
-		<string>b'</string>
+		<string>b</string>
 	</array>
 	<key>@MMK_R_b.sc</key>
 	<array>
-		<string>b.sc'</string>
+		<string>b.sc</string>
 		<string>d.sc</string>
 		<string>dcaron.sc</string>
 		<string>dcroat.sc</string>
@@ -1326,11 +1326,11 @@
 	</array>
 	<key>@MMK_R_backslash</key>
 	<array>
-		<string>backslash'</string>
+		<string>backslash</string>
 	</array>
 	<key>@MMK_R_bracketleft</key>
 	<array>
-		<string>Hbar'</string>
+		<string>Hbar</string>
 		<string>zero.lining.sup</string>
 		<string>one.lining.sup</string>
 		<string>two.lining.sup</string>
@@ -1362,14 +1362,14 @@
 	</array>
 	<key>@MMK_R_bracketright</key>
 	<array>
-		<string>braceright'</string>
+		<string>braceright</string>
 		<string>bracketright</string>
 		<string>braceright.uppercase</string>
 		<string>bracketright.uppercase</string>
 	</array>
 	<key>@MMK_R_bullet</key>
 	<array>
-		<string>bullet'</string>
+		<string>bullet</string>
 		<string>emdash.uppercase</string>
 		<string>endash.uppercase</string>
 		<string>figuredash.uppercase</string>
@@ -1381,11 +1381,11 @@
 	</array>
 	<key>@MMK_R_comma</key>
 	<array>
-		<string>comma'</string>
+		<string>comma</string>
 	</array>
 	<key>@MMK_R_dollar.lining.sub</key>
 	<array>
-		<string>zero.lining.sub'</string>
+		<string>zero.lining.sub</string>
 		<string>one.lining.sub</string>
 		<string>two.lining.sub</string>
 		<string>three.lining.sub</string>
@@ -1405,11 +1405,11 @@
 	</array>
 	<key>@MMK_R_dotlessj</key>
 	<array>
-		<string>dotlessj'</string>
+		<string>dotlessj</string>
 	</array>
 	<key>@MMK_R_e.sc</key>
 	<array>
-		<string>e.sc'</string>
+		<string>e.sc</string>
 		<string>eacute.sc</string>
 		<string>ebreve.sc</string>
 		<string>ecaron.sc</string>
@@ -1422,31 +1422,31 @@
 	</array>
 	<key>@MMK_R_ebreve</key>
 	<array>
-		<string>ebreve'</string>
+		<string>ebreve</string>
 	</array>
 	<key>@MMK_R_ecaron</key>
 	<array>
-		<string>ecaron'</string>
+		<string>ecaron</string>
 	</array>
 	<key>@MMK_R_edieresis</key>
 	<array>
-		<string>edieresis'</string>
+		<string>edieresis</string>
 	</array>
 	<key>@MMK_R_egrave</key>
 	<array>
-		<string>egrave'</string>
+		<string>egrave</string>
 	</array>
 	<key>@MMK_R_eight</key>
 	<array>
-		<string>eight'</string>
+		<string>eight</string>
 	</array>
 	<key>@MMK_R_eth</key>
 	<array>
-		<string>eth'</string>
+		<string>eth</string>
 	</array>
 	<key>@MMK_R_exclam</key>
 	<array>
-		<string>B'</string>
+		<string>B</string>
 		<string>D</string>
 		<string>Dcaron</string>
 		<string>Dcroat</string>
@@ -1512,7 +1512,7 @@
 	</array>
 	<key>@MMK_R_f</key>
 	<array>
-		<string>f'</string>
+		<string>f</string>
 		<string>f_b</string>
 		<string>f_f</string>
 		<string>f_f_b</string>
@@ -1529,19 +1529,19 @@
 	</array>
 	<key>@MMK_R_f.sc</key>
 	<array>
-		<string>f.sc'</string>
+		<string>f.sc</string>
 	</array>
 	<key>@MMK_R_five</key>
 	<array>
-		<string>five'</string>
+		<string>five</string>
 	</array>
 	<key>@MMK_R_florin</key>
 	<array>
-		<string>florin'</string>
+		<string>florin</string>
 	</array>
 	<key>@MMK_R_four</key>
 	<array>
-		<string>a.sc'</string>
+		<string>a.sc</string>
 		<string>aacute.sc</string>
 		<string>abreve.sc</string>
 		<string>acircumflex.sc</string>
@@ -1555,23 +1555,23 @@
 	</array>
 	<key>@MMK_R_g</key>
 	<array>
-		<string>g'</string>
+		<string>g</string>
 		<string>gcircumflex</string>
 		<string>gcommaaccent</string>
 		<string>gdotaccent</string>
 	</array>
 	<key>@MMK_R_gbreve</key>
 	<array>
-		<string>gbreve'</string>
+		<string>gbreve</string>
 	</array>
 	<key>@MMK_R_germandbls</key>
 	<array>
-		<string>germandbls'</string>
+		<string>germandbls</string>
 		<string>longs</string>
 	</array>
 	<key>@MMK_R_grave</key>
 	<array>
-		<string>onequarter'</string>
+		<string>onequarter</string>
 		<string>onehalf</string>
 		<string>threequarters</string>
 		<string>zero.lining.numer</string>
@@ -1654,17 +1654,17 @@
 	</array>
 	<key>@MMK_R_guillemotleft</key>
 	<array>
-		<string>guillemotleft'</string>
+		<string>guillemotleft</string>
 		<string>guilsinglleft</string>
 	</array>
 	<key>@MMK_R_guillemotleft.uppercase</key>
 	<array>
-		<string>guillemotleft.uppercase'</string>
+		<string>guillemotleft.uppercase</string>
 		<string>guilsinglleft.uppercase</string>
 	</array>
 	<key>@MMK_R_h</key>
 	<array>
-		<string>h'</string>
+		<string>h</string>
 		<string>hbar</string>
 		<string>hcircumflex</string>
 		<string>l</string>
@@ -1674,14 +1674,14 @@
 	</array>
 	<key>@MMK_R_h.sc</key>
 	<array>
-		<string>h.sc'</string>
+		<string>h.sc</string>
 		<string>hbar.sc</string>
 		<string>hcircumflex.sc</string>
 		<string>p.sc</string>
 	</array>
 	<key>@MMK_R_hyphen</key>
 	<array>
-		<string>c'</string>
+		<string>c</string>
 		<string>cacute</string>
 		<string>ccaron</string>
 		<string>ccedilla</string>
@@ -1746,105 +1746,105 @@
 	</array>
 	<key>@MMK_R_i</key>
 	<array>
-		<string>i'</string>
+		<string>i</string>
 		<string>ij</string>
 		<string>i.TRK</string>
 	</array>
 	<key>@MMK_R_i.sc</key>
 	<array>
-		<string>i.TRK.sc'</string>
+		<string>i.TRK.sc</string>
 		<string>i.sc</string>
 		<string>iacute.sc</string>
 	</array>
 	<key>@MMK_R_iacute</key>
 	<array>
-		<string>iacute'</string>
+		<string>iacute</string>
 	</array>
 	<key>@MMK_R_ibreve</key>
 	<array>
-		<string>ibreve'</string>
+		<string>ibreve</string>
 	</array>
 	<key>@MMK_R_ibreve.sc</key>
 	<array>
-		<string>ibreve.sc'</string>
+		<string>ibreve.sc</string>
 	</array>
 	<key>@MMK_R_icircumflex</key>
 	<array>
-		<string>icircumflex'</string>
+		<string>icircumflex</string>
 	</array>
 	<key>@MMK_R_icircumflex.sc</key>
 	<array>
-		<string>icircumflex.sc'</string>
+		<string>icircumflex.sc</string>
 	</array>
 	<key>@MMK_R_idieresis</key>
 	<array>
-		<string>idieresis'</string>
+		<string>idieresis</string>
 	</array>
 	<key>@MMK_R_idieresis.sc</key>
 	<array>
-		<string>idieresis.sc'</string>
+		<string>idieresis.sc</string>
 	</array>
 	<key>@MMK_R_igrave</key>
 	<array>
-		<string>igrave'</string>
+		<string>igrave</string>
 	</array>
 	<key>@MMK_R_igrave.sc</key>
 	<array>
-		<string>igrave.sc'</string>
+		<string>igrave.sc</string>
 	</array>
 	<key>@MMK_R_imacron</key>
 	<array>
-		<string>imacron'</string>
+		<string>imacron</string>
 	</array>
 	<key>@MMK_R_imacron.sc</key>
 	<array>
-		<string>imacron.sc'</string>
+		<string>imacron.sc</string>
 	</array>
 	<key>@MMK_R_iogonek</key>
 	<array>
-		<string>iogonek'</string>
+		<string>iogonek</string>
 	</array>
 	<key>@MMK_R_iogonek.sc</key>
 	<array>
-		<string>iogonek.sc'</string>
+		<string>iogonek.sc</string>
 	</array>
 	<key>@MMK_R_itilde</key>
 	<array>
-		<string>itilde'</string>
+		<string>itilde</string>
 	</array>
 	<key>@MMK_R_itilde.sc</key>
 	<array>
-		<string>itilde.sc'</string>
+		<string>itilde.sc</string>
 	</array>
 	<key>@MMK_R_j</key>
 	<array>
-		<string>j'</string>
+		<string>j</string>
 	</array>
 	<key>@MMK_R_j.sc</key>
 	<array>
-		<string>j.sc'</string>
+		<string>j.sc</string>
 	</array>
 	<key>@MMK_R_jcircumflex</key>
 	<array>
-		<string>jcircumflex'</string>
+		<string>jcircumflex</string>
 	</array>
 	<key>@MMK_R_jcircumflex.sc</key>
 	<array>
-		<string>jcircumflex.sc'</string>
+		<string>jcircumflex.sc</string>
 	</array>
 	<key>@MMK_R_k</key>
 	<array>
-		<string>k'</string>
+		<string>k</string>
 		<string>kcommaaccent</string>
 	</array>
 	<key>@MMK_R_k.sc</key>
 	<array>
-		<string>k.sc'</string>
+		<string>k.sc</string>
 		<string>kcommaaccent.sc</string>
 	</array>
 	<key>@MMK_R_l.sc</key>
 	<array>
-		<string>l.sc'</string>
+		<string>l.sc</string>
 		<string>lacute.sc</string>
 		<string>lcaron.sc</string>
 		<string>lcommaaccent.sc</string>
@@ -1852,23 +1852,23 @@
 	</array>
 	<key>@MMK_R_ldot</key>
 	<array>
-		<string>ldot'</string>
+		<string>ldot</string>
 	</array>
 	<key>@MMK_R_ldot.sc</key>
 	<array>
-		<string>ldot.sc'</string>
+		<string>ldot.sc</string>
 	</array>
 	<key>@MMK_R_m.sc</key>
 	<array>
-		<string>m.sc'</string>
+		<string>m.sc</string>
 	</array>
 	<key>@MMK_R_micro</key>
 	<array>
-		<string>micro'</string>
+		<string>micro</string>
 	</array>
 	<key>@MMK_R_n.sc</key>
 	<array>
-		<string>n.sc'</string>
+		<string>n.sc</string>
 		<string>nacute.sc</string>
 		<string>ncaron.sc</string>
 		<string>ncommaaccent.sc</string>
@@ -1876,76 +1876,76 @@
 	</array>
 	<key>@MMK_R_napostrophe</key>
 	<array>
-		<string>napostrophe'</string>
+		<string>napostrophe</string>
 	</array>
 	<key>@MMK_R_nine</key>
 	<array>
-		<string>nine'</string>
+		<string>nine</string>
 	</array>
 	<key>@MMK_R_numbersign</key>
 	<array>
-		<string>numbersign'</string>
+		<string>numbersign</string>
 		<string>currency</string>
 	</array>
 	<key>@MMK_R_one</key>
 	<array>
-		<string>one'</string>
+		<string>one</string>
 		<string>colon</string>
 	</array>
 	<key>@MMK_R_ordfeminine</key>
 	<array>
-		<string>ordfeminine'</string>
+		<string>ordfeminine</string>
 		<string>degree</string>
 	</array>
 	<key>@MMK_R_ordmasculine</key>
 	<array>
-		<string>ordmasculine'</string>
+		<string>ordmasculine</string>
 	</array>
 	<key>@MMK_R_p</key>
 	<array>
-		<string>p'</string>
+		<string>p</string>
 	</array>
 	<key>@MMK_R_paragraph</key>
 	<array>
-		<string>Iogonek'</string>
+		<string>Iogonek</string>
 		<string>paragraph</string>
 	</array>
 	<key>@MMK_R_parenleft</key>
 	<array>
-		<string>parenleft'</string>
+		<string>parenleft</string>
 	</array>
 	<key>@MMK_R_parenleft.uppercase</key>
 	<array>
-		<string>parenleft.uppercase'</string>
+		<string>parenleft.uppercase</string>
 	</array>
 	<key>@MMK_R_parenright</key>
 	<array>
-		<string>parenright'</string>
+		<string>parenright</string>
 	</array>
 	<key>@MMK_R_parenright.uppercase</key>
 	<array>
-		<string>parenright.uppercase'</string>
+		<string>parenright.uppercase</string>
 	</array>
 	<key>@MMK_R_percent</key>
 	<array>
-		<string>percent'</string>
+		<string>percent</string>
 	</array>
 	<key>@MMK_R_period</key>
 	<array>
-		<string>ellipsis'</string>
+		<string>ellipsis</string>
 		<string>period</string>
 	</array>
 	<key>@MMK_R_periodcentered</key>
 	<array>
-		<string>periodcentered'</string>
+		<string>periodcentered</string>
 	</array>
 	<key>@MMK_R_periodcentered.sc</key>
 	<array>
-		<string>periodcentered.sc'</string>
+		<string>periodcentered.sc</string>
 	</array>
 	<key>@MMK_R_plus</key>
 	<array>
-		<string>a'</string>
+		<string>a</string>
 		<string>aacute</string>
 		<string>acircumflex</string>
 		<string>ae</string>
@@ -1979,33 +1979,33 @@
 	</array>
 	<key>@MMK_R_q.sc</key>
 	<array>
-		<string>q.sc'</string>
+		<string>q.sc</string>
 	</array>
 	<key>@MMK_R_quotedbl</key>
 	<array>
-		<string>quotedbl'</string>
+		<string>quotedbl</string>
 		<string>quotesingle</string>
 		<string>quotedblright</string>
 		<string>quoteright</string>
 	</array>
 	<key>@MMK_R_quoteleft</key>
 	<array>
-		<string>quotedblleft'</string>
+		<string>quotedblleft</string>
 		<string>quoteleft</string>
 	</array>
 	<key>@MMK_R_quotereversed</key>
 	<array>
-		<string>quotereversed'</string>
+		<string>quotereversed</string>
 		<string>uni201F</string>
 	</array>
 	<key>@MMK_R_quotesinglbase</key>
 	<array>
-		<string>quotedblbase'</string>
+		<string>quotedblbase</string>
 		<string>quotesinglbase</string>
 	</array>
 	<key>@MMK_R_r</key>
 	<array>
-		<string>r'</string>
+		<string>r</string>
 		<string>racute</string>
 		<string>rcommaaccent</string>
 		<string>z.sc</string>
@@ -2015,22 +2015,22 @@
 	</array>
 	<key>@MMK_R_r.sc</key>
 	<array>
-		<string>r.sc'</string>
+		<string>r.sc</string>
 		<string>racute.sc</string>
 		<string>rcaron.sc</string>
 		<string>rcommaaccent.sc</string>
 	</array>
 	<key>@MMK_R_rcaron</key>
 	<array>
-		<string>rcaron'</string>
+		<string>rcaron</string>
 	</array>
 	<key>@MMK_R_registered</key>
 	<array>
-		<string>registered'</string>
+		<string>registered</string>
 	</array>
 	<key>@MMK_R_s.sc</key>
 	<array>
-		<string>s.sc'</string>
+		<string>s.sc</string>
 		<string>sacute.sc</string>
 		<string>scaron.sc</string>
 		<string>scedilla.sc</string>
@@ -2039,38 +2039,38 @@
 	</array>
 	<key>@MMK_R_scaron</key>
 	<array>
-		<string>scaron'</string>
+		<string>scaron</string>
 	</array>
 	<key>@MMK_R_section</key>
 	<array>
-		<string>section'</string>
+		<string>section</string>
 	</array>
 	<key>@MMK_R_semicolon</key>
 	<array>
-		<string>semicolon'</string>
+		<string>semicolon</string>
 	</array>
 	<key>@MMK_R_six</key>
 	<array>
-		<string>six'</string>
+		<string>six</string>
 	</array>
 	<key>@MMK_R_slash</key>
 	<array>
-		<string>slash'</string>
+		<string>slash</string>
 	</array>
 	<key>@MMK_R_sterling</key>
 	<array>
-		<string>sterling'</string>
+		<string>sterling</string>
 	</array>
 	<key>@MMK_R_t</key>
 	<array>
-		<string>t'</string>
+		<string>t</string>
 		<string>tcaron</string>
 		<string>tcedilla</string>
 		<string>tcommaaccent</string>
 	</array>
 	<key>@MMK_R_t.sc</key>
 	<array>
-		<string>t.sc'</string>
+		<string>t.sc</string>
 		<string>tbar.sc</string>
 		<string>tcaron.sc</string>
 		<string>tcedilla.sc</string>
@@ -2078,28 +2078,28 @@
 	</array>
 	<key>@MMK_R_tbar</key>
 	<array>
-		<string>tbar'</string>
+		<string>tbar</string>
 	</array>
 	<key>@MMK_R_thorn</key>
 	<array>
-		<string>thorn'</string>
+		<string>thorn</string>
 	</array>
 	<key>@MMK_R_thorn.sc</key>
 	<array>
-		<string>thorn.sc'</string>
+		<string>thorn.sc</string>
 	</array>
 	<key>@MMK_R_three</key>
 	<array>
-		<string>three'</string>
+		<string>three</string>
 		<string>seven</string>
 	</array>
 	<key>@MMK_R_two</key>
 	<array>
-		<string>two'</string>
+		<string>two</string>
 	</array>
 	<key>@MMK_R_u</key>
 	<array>
-		<string>u'</string>
+		<string>u</string>
 		<string>uacute</string>
 		<string>ubreve</string>
 		<string>ucircumflex</string>
@@ -2113,7 +2113,7 @@
 	</array>
 	<key>@MMK_R_u.sc</key>
 	<array>
-		<string>u.sc'</string>
+		<string>u.sc</string>
 		<string>uacute.sc</string>
 		<string>ubreve.sc</string>
 		<string>ucircumflex.sc</string>
@@ -2127,11 +2127,11 @@
 	</array>
 	<key>@MMK_R_underscore</key>
 	<array>
-		<string>underscore'</string>
+		<string>underscore</string>
 	</array>
 	<key>@MMK_R_v</key>
 	<array>
-		<string>v'</string>
+		<string>v</string>
 		<string>w</string>
 		<string>wcircumflex</string>
 		<string>y</string>
@@ -2141,32 +2141,32 @@
 	</array>
 	<key>@MMK_R_v.sc</key>
 	<array>
-		<string>v.sc'</string>
+		<string>v.sc</string>
 		<string>w.sc</string>
 		<string>wcircumflex.sc</string>
 	</array>
 	<key>@MMK_R_x</key>
 	<array>
-		<string>x'</string>
+		<string>x</string>
 	</array>
 	<key>@MMK_R_x.sc</key>
 	<array>
-		<string>x.sc'</string>
+		<string>x.sc</string>
 	</array>
 	<key>@MMK_R_y.sc</key>
 	<array>
-		<string>y.sc'</string>
+		<string>y.sc</string>
 		<string>yacute.sc</string>
 		<string>ycircumflex.sc</string>
 		<string>ydieresis.sc</string>
 	</array>
 	<key>@MMK_R_yen</key>
 	<array>
-		<string>yen'</string>
+		<string>yen</string>
 	</array>
 	<key>@MMK_R_zcaron</key>
 	<array>
-		<string>zcaron'</string>
+		<string>zcaron</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Removes the extra apostrophe at the end of the first string of each `<array>` of the `<dict>` in `groups.plist`'s.

Fixes https://github.com/theleagueof/sorts-mill-goudy/issues/7

This fix is probably included also in [this other PR](https://github.com/theleagueof/sorts-mill-goudy/pull/5), but it seems to me good practice to keep individual issues separate. 